### PR TITLE
install simulator-core from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1160,17 +1160,25 @@
       }
     },
     "@fruk/simulator-core": {
-      "version": "git+https://github.com/FRUK-Simulator/SimulatorCore.git#2a7adbad25ac4f022e37a035f4c1c98bfff42fd8",
-      "from": "git+https://github.com/FRUK-Simulator/SimulatorCore.git",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@fruk/simulator-core/-/simulator-core-1.0.0.tgz",
+      "integrity": "sha512-jH82ueHA5rYkvHSEu9JJU67Siv8bQ6O6AOH3dWbmM97BP9sZXsqZvgwiU2i/P+e9Y0kk/tTyM5tZlvx/Tta/Cw==",
       "requires": {
+        "planck-js": "^0.3.18",
         "three": "^0.117.1",
-        "typescript": "^3.9.5"
+        "typescript": "^3.9.5",
+        "uuid": "^8.1.0"
       },
       "dependencies": {
         "typescript": {
           "version": "3.9.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
           "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ=="
+        },
+        "uuid": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
         }
       }
     },
@@ -10322,6 +10330,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "planck-js": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/planck-js/-/planck-js-0.3.18.tgz",
+      "integrity": "sha512-QX++sjjHszmgVti6tUUCwbJxHkrIGMeymat1+sDNDPZYSCrbx1vBAZbKpjzz/r7H97yAxPVLfB8ohq7ONTqpeQ=="
     },
     "please-upgrade-node": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@fluentui/react": "^7.117.3",
-    "@fruk/simulator-core": "git+https://github.com/FRUK-Simulator/SimulatorCore.git",
+    "@fruk/simulator-core": "1.0.0",
     "@reduxjs/toolkit": "^1.3.6",
     "@uifabric/icons": "^7.3.48",
     "blockly": "^3.20200402.1",


### PR DESCRIPTION
I made it an exact version and not `^1.0.0` because there's a good chance we might not follow sem versioning in the beginning stages. I think we should use exact versions until things are stable and we really are just publishing minor and patches with guaranteed no breaking changes (or bugs :))