### PR TITLE
Add reset button

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@fluentui/react": "^7.117.3",
-    "@fruk/simulator-core": "1.0.6",
+    "@fruk/simulator-core": "1.1.0",
     "@reduxjs/toolkit": "^1.3.6",
     "@uifabric/icons": "^7.3.48",
     "blockly": "^3.20200402.1",

--- a/src/JavascriptVM/JavascriptVM.css
+++ b/src/JavascriptVM/JavascriptVM.css
@@ -5,11 +5,16 @@
 }
 
 .javascript-vm-controls {
-  min-width: 256px;
+  min-width: 330px;
 }
 
 .javascript-vm-controls--stop-button,
 .javascript-vm-controls--stop-button:hover {
+  color: #dc3545;
+}
+
+.javascript-vm-controls--reset-button,
+.javascript-vm-controls--reset-button:hover {
   color: #dc3545;
 }
 

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState, createContext } from "react";
+import { FunctionComponent, useState, createContext, useRef } from "react";
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { vmSlice } from "./vmSlice";
@@ -26,6 +26,8 @@ export interface IVirtualMachine {
   stop: () => void;
   start: () => void;
   pause: () => void;
+  linkReset(reset: () => void): void;
+  resetSimulator: () => void;
 }
 
 /**
@@ -50,6 +52,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
   );
   const dispatch = useDispatch<AppDispatch>();
   const code = useSelector(getCode);
+  const resetLink = useRef<() => void | undefined>();
 
   /**
    * Syncs the redux state with the interpreter state.
@@ -150,6 +153,14 @@ export const VMProvider: FunctionComponent = ({ children }) => {
                 msg: "Code cannot be executed.",
               })
             );
+          }
+        },
+        linkReset(reset: () => void): void {
+          resetLink.current = reset;
+        },
+        resetSimulator(): void {
+          if (resetLink.current) {
+            resetLink.current();
           }
         },
       }}

--- a/src/JavascriptVM/VMControls.tsx
+++ b/src/JavascriptVM/VMControls.tsx
@@ -71,7 +71,19 @@ export const VMControls: FunctionComponent = () => {
       className: "javascript-vm-controls--stop-button",
     },
   };
+  const resetButton: ICommandBarItemProps = {
+    onClick() {
+      controls.resetSimulator();
+    },
+    key: "reset",
+    text: "Reset",
+    iconProps: {
+      iconName: "Rewind",
+      className: "javascript-vm-controls--reset-button",
+    },
+  };
   const commandBarRunningItems: ICommandBarItemProps[] = [
+    resetButton,
     stopButton,
     executionStatus === ExecutionState.RUNNING
       ? { ...stepButton, disabled: true }
@@ -79,6 +91,7 @@ export const VMControls: FunctionComponent = () => {
     executionStatus === ExecutionState.RUNNING ? pauseButton : runButton,
   ];
   const commandBarStoppedItems: ICommandBarItemProps[] = [
+    resetButton,
     { ...startButton, disabled: !code },
     { ...stepButton, disabled: true },
     { ...runButton, disabled: true },


### PR DESCRIPTION
This also shows a method for accessing things about the simulator from other places.
here i'm using the JavascriptVM Context to act as a middle man.
Its pretty clean (not many lines of code) but i think its a bit messy from an architectural point of view.

Maybe we should think about hoisting the simulator integration up into that JavascriptVM Context. or making some form of amalgamation of them both.