### PR TITLE
Add general purpose blocks from FTC blockly implementation

### DIFF
--- a/src/BlocklyInterface/robotblocks/constants/ConstantsSection.ts
+++ b/src/BlocklyInterface/robotblocks/constants/ConstantsSection.ts
@@ -1,8 +1,0 @@
-export default (() => {
-  return `
-<category name="Constants">
-    <block type="text"></block>
-    <block type="math_number"></block>
-</category>
-`;
-})();

--- a/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
+++ b/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
@@ -1,0 +1,374 @@
+/*
+ * Code taken and lightly modified from FTC Blockly application. Modifications
+ * cover global variable usage from other files that are not suitable to be
+ * directly copied across, or are themselves transpiled from unknown sources
+ */
+
+// The below lines are the additions to the FTC original general block
+// definition to cover transpiled code parts
+import Blockly from "blockly";
+const miscIdentifierForJavaScript = "miscAccess";
+const functionColor = 289;
+const commentColor = 200;
+
+function createNonEditableField(label) {
+  var field = new Blockly.FieldTextInput(label);
+  field.CURSOR = "";
+  field.showEditor_ = function (opt_quietInput) {};
+  return field;
+}
+
+// FTC copied code begins here
+
+Blockly.Blocks["comment"] = {
+  init: function () {
+    this.appendDummyInput().appendField(
+      new Blockly.FieldTextInput(""),
+      "COMMENT"
+    );
+    this.setPreviousStatement(true);
+    this.setNextStatement(true);
+    this.setColour(commentColor);
+  },
+};
+
+Blockly.JavaScript["comment"] = function (block) {
+  return "";
+};
+
+Blockly.JavaScript["comment"] = function (block) {
+  return "// " + block.getFieldValue("COMMENT") + "\n";
+};
+
+Blockly.Blocks["misc_null"] = {
+  init: function () {
+    this.setOutput(true); // no type for null
+    this.appendDummyInput().appendField(createNonEditableField("null"));
+    this.setColour(functionColor);
+    this.setTooltip("null");
+  },
+};
+
+Blockly.JavaScript["misc_null"] = function (block) {
+  var code = miscIdentifierForJavaScript + ".getNull()";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.JavaScript["misc_null"] = function (block) {
+  return ["null", Blockly.JavaScript.ORDER_ATOMIC];
+};
+
+Blockly.Blocks["misc_isNull"] = {
+  init: function () {
+    this.setOutput(true, "Boolean");
+    this.appendDummyInput()
+      .appendField("call")
+      .appendField(createNonEditableField("isNull"));
+    this.appendValueInput("VALUE") // all types allowed
+      .appendField("value")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.setColour(functionColor);
+    this.setTooltip(
+      "Returns true if the given value is null, false otherwise."
+    );
+  },
+};
+
+Blockly.JavaScript["misc_isNull"] = function (block) {
+  var value = Blockly.JavaScript.valueToCode(
+    block,
+    "VALUE",
+    Blockly.JavaScript.ORDER_NONE
+  );
+  var code = miscIdentifierForJavaScript + ".isNull(" + value + ")";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.JavaScript["misc_isNull"] = function (block) {
+  var value = Blockly.JavaScript.valueToCode(
+    block,
+    "VALUE",
+    Blockly.JavaScript.ORDER_EQUALITY
+  );
+  var code = value + " == null";
+  return [code, Blockly.JavaScript.ORDER_EQUALITY];
+};
+
+Blockly.Blocks["misc_isNotNull"] = {
+  init: function () {
+    this.setOutput(true, "Boolean");
+    this.appendDummyInput()
+      .appendField("call")
+      .appendField(createNonEditableField("isNotNull"));
+    this.appendValueInput("VALUE") // all types allowed
+      .appendField("value")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.setColour(functionColor);
+    this.setTooltip(
+      "Returns true if the given value is not null, false otherwise."
+    );
+  },
+};
+
+Blockly.JavaScript["misc_isNotNull"] = function (block) {
+  var value = Blockly.JavaScript.valueToCode(
+    block,
+    "VALUE",
+    Blockly.JavaScript.ORDER_NONE
+  );
+  var code = miscIdentifierForJavaScript + ".isNotNull(" + value + ")";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.JavaScript["misc_isNotNull"] = function (block) {
+  var value = Blockly.JavaScript.valueToCode(
+    block,
+    "VALUE",
+    Blockly.JavaScript.ORDER_EQUALITY
+  );
+  var code = value + " != null";
+  return [code, Blockly.JavaScript.ORDER_EQUALITY];
+};
+
+Blockly.Blocks["misc_atan2"] = {
+  init: function () {
+    this.setOutput(true, "Number");
+    this.appendDummyInput().appendField("atan2");
+    this.appendValueInput("Y")
+      .setCheck("Number")
+      .appendField("y")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.appendValueInput("X")
+      .setCheck("Number")
+      .appendField("x")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.setColour(Blockly.Msg.MATH_HUE);
+    this.setTooltip(
+      "Returns a numerical value between -180 and +180 degrees, representing " +
+        "the counterclockwise angle between the positive X axis, and the point (x, y)."
+    );
+    this.getJavaScriptInputType = function (inputName) {
+      switch (inputName) {
+        case "Y":
+        case "X":
+          return "double";
+      }
+      return "";
+    };
+    this.getJavaScriptOutputType = function () {
+      return "double";
+    };
+  },
+};
+
+Blockly.JavaScript["misc_atan2"] = function (block) {
+  var y = Blockly.JavaScript.valueToCode(
+    block,
+    "Y",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var x = Blockly.JavaScript.valueToCode(
+    block,
+    "X",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var code = "Math.atan2(" + y + ", " + x + ") / Math.PI * 180";
+  return [code, Blockly.JavaScript.ORDER_DIVISION];
+};
+
+Blockly.JavaScript["misc_atan2"] = function (block) {
+  var y = Blockly.JavaScript.valueToCode(
+    block,
+    "Y",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var x = Blockly.JavaScript.valueToCode(
+    block,
+    "X",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var code = "Math.atan2(" + y + ", " + x + ") / Math.PI * 180";
+  return [code, Blockly.JavaScript.ORDER_MULTIPLICATION];
+};
+
+Blockly.Blocks["misc_formatNumber"] = {
+  init: function () {
+    this.setOutput(true, "String");
+    this.appendDummyInput()
+      .appendField("call")
+      .appendField(createNonEditableField("formatNumber"));
+    this.appendValueInput("NUMBER")
+      .setCheck("Number")
+      .appendField("number")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.appendValueInput("PRECISION")
+      .setCheck("Number")
+      .appendField("precision")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.setColour(functionColor);
+    this.setTooltip(
+      "Returns a text value of the given number formatted with the given precision, padded with zeros if necessary."
+    );
+    this.getJavaScriptInputType = function (inputName) {
+      switch (inputName) {
+        case "NUMBER":
+          return "double";
+        case "PRECISION":
+          return "int";
+      }
+      return "";
+    };
+  },
+};
+
+Blockly.JavaScript["misc_formatNumber"] = function (block) {
+  var number = Blockly.JavaScript.valueToCode(
+    block,
+    "NUMBER",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var precision = Blockly.JavaScript.valueToCode(
+    block,
+    "PRECISION",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var code =
+    miscIdentifierForJavaScript +
+    ".formatNumber(" +
+    number +
+    ", " +
+    precision +
+    ")";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.JavaScript["misc_formatNumber"] = function (block) {
+  var number = Blockly.JavaScript.valueToCode(
+    block,
+    "NUMBER",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var precision = Blockly.JavaScript.valueToCode(
+    block,
+    "PRECISION",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  // Due to issues with floating point precision, we always call the JavaUtil method.
+  Blockly.JavaScript.generateImport_("JavaUtil");
+  var code = "JavaUtil.formatNumber(" + number + ", " + precision + ")";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Blocks["misc_roundDecimal"] = {
+  init: function () {
+    this.setOutput(true, "Number");
+    this.appendDummyInput()
+      .appendField("call")
+      .appendField(createNonEditableField("roundDecimal"));
+    this.appendValueInput("NUMBER")
+      .setCheck("Number")
+      .appendField("number")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.appendValueInput("PRECISION")
+      .setCheck("Number")
+      .appendField("precision")
+      .setAlign(Blockly.ALIGN_RIGHT);
+    this.setColour(functionColor);
+    this.setTooltip(
+      "Returns a numeric value of the given number rounded to the given precision."
+    );
+    this.getJavaScriptInputType = function (inputName) {
+      switch (inputName) {
+        case "NUMBER":
+          return "double";
+        case "PRECISION":
+          return "int";
+      }
+      return "";
+    };
+  },
+};
+
+Blockly.JavaScript["misc_roundDecimal"] = function (block) {
+  var number = Blockly.JavaScript.valueToCode(
+    block,
+    "NUMBER",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var precision = Blockly.JavaScript.valueToCode(
+    block,
+    "PRECISION",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var code =
+    miscIdentifierForJavaScript +
+    ".roundDecimal(" +
+    number +
+    ", " +
+    precision +
+    ")";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.JavaScript["misc_roundDecimal"] = function (block) {
+  var number = Blockly.JavaScript.valueToCode(
+    block,
+    "NUMBER",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  var precision = Blockly.JavaScript.valueToCode(
+    block,
+    "PRECISION",
+    Blockly.JavaScript.ORDER_COMMA
+  );
+  // Due to issues with floating point precision, we always call the JavaUtil method.
+  Blockly.JavaScript.generateImport_("JavaUtil");
+  var code =
+    "Double.parseDouble(JavaUtil.formatNumber(" +
+    number +
+    ", " +
+    precision +
+    "))";
+  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Blocks["misc_addItemToList"] = {
+  init: function () {
+    this.appendDummyInput().appendField("add item");
+    this.appendValueInput("ITEM");
+    this.appendDummyInput().appendField("to list");
+    this.appendValueInput("LIST").setCheck("Array");
+    this.setPreviousStatement(true);
+    this.setNextStatement(true);
+    this.setColour(Blockly.Msg.LISTS_HUE);
+    this.setTooltip("Add the item to the end of the list.");
+  },
+};
+
+Blockly.JavaScript["misc_addItemToList"] = function (block) {
+  var item = Blockly.JavaScript.valueToCode(
+    block,
+    "ITEM",
+    Blockly.JavaScript.ORDER_NONE
+  );
+  var list = Blockly.JavaScript.valueToCode(
+    block,
+    "LIST",
+    Blockly.JavaScript.ORDER_MEMBER
+  );
+  return list + ".push(" + item + ")";
+};
+
+Blockly.JavaScript["misc_addItemToList"] = function (block) {
+  var item = Blockly.JavaScript.valueToCode(
+    block,
+    "ITEM",
+    Blockly.JavaScript.ORDER_NONE
+  );
+  var list = Blockly.JavaScript.valueToCode(
+    block,
+    "LIST",
+    Blockly.JavaScript.ORDER_MEMBER
+  );
+  return list + ".add(" + item + ")";
+};

--- a/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
+++ b/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
@@ -152,8 +152,9 @@ Blockly.Blocks["misc_atan2"] = {
         case "Y":
         case "X":
           return "double";
+        default:
+          return "";
       }
-      return "";
     };
     this.getJavaScriptOutputType = function () {
       return "double";
@@ -215,8 +216,9 @@ Blockly.Blocks["misc_formatNumber"] = {
           return "double";
         case "PRECISION":
           return "int";
+        default:
+          return "";
       }
-      return "";
     };
   },
 };
@@ -283,8 +285,9 @@ Blockly.Blocks["misc_roundDecimal"] = {
           return "double";
         case "PRECISION":
           return "int";
+        default:
+          return "";
       }
-      return "";
     };
   },
 };

--- a/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
+++ b/src/BlocklyInterface/robotblocks/general/GeneralBlocks.js
@@ -7,7 +7,6 @@
 // The below lines are the additions to the FTC original general block
 // definition to cover transpiled code parts
 import Blockly from "blockly";
-const miscIdentifierForJavaScript = "miscAccess";
 const functionColor = 289;
 const commentColor = 200;
 
@@ -33,10 +32,6 @@ Blockly.Blocks["comment"] = {
 };
 
 Blockly.JavaScript["comment"] = function (block) {
-  return "";
-};
-
-Blockly.JavaScript["comment"] = function (block) {
   return "// " + block.getFieldValue("COMMENT") + "\n";
 };
 
@@ -47,11 +42,6 @@ Blockly.Blocks["misc_null"] = {
     this.setColour(functionColor);
     this.setTooltip("null");
   },
-};
-
-Blockly.JavaScript["misc_null"] = function (block) {
-  var code = miscIdentifierForJavaScript + ".getNull()";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
 };
 
 Blockly.JavaScript["misc_null"] = function (block) {
@@ -78,19 +68,9 @@ Blockly.JavaScript["misc_isNull"] = function (block) {
   var value = Blockly.JavaScript.valueToCode(
     block,
     "VALUE",
-    Blockly.JavaScript.ORDER_NONE
-  );
-  var code = miscIdentifierForJavaScript + ".isNull(" + value + ")";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
-Blockly.JavaScript["misc_isNull"] = function (block) {
-  var value = Blockly.JavaScript.valueToCode(
-    block,
-    "VALUE",
     Blockly.JavaScript.ORDER_EQUALITY
   );
-  var code = value + " == null";
+  var code = value + " === null";
   return [code, Blockly.JavaScript.ORDER_EQUALITY];
 };
 
@@ -114,19 +94,9 @@ Blockly.JavaScript["misc_isNotNull"] = function (block) {
   var value = Blockly.JavaScript.valueToCode(
     block,
     "VALUE",
-    Blockly.JavaScript.ORDER_NONE
-  );
-  var code = miscIdentifierForJavaScript + ".isNotNull(" + value + ")";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
-Blockly.JavaScript["misc_isNotNull"] = function (block) {
-  var value = Blockly.JavaScript.valueToCode(
-    block,
-    "VALUE",
     Blockly.JavaScript.ORDER_EQUALITY
   );
-  var code = value + " != null";
+  var code = value + " !== null";
   return [code, Blockly.JavaScript.ORDER_EQUALITY];
 };
 
@@ -177,164 +147,6 @@ Blockly.JavaScript["misc_atan2"] = function (block) {
   return [code, Blockly.JavaScript.ORDER_DIVISION];
 };
 
-Blockly.JavaScript["misc_atan2"] = function (block) {
-  var y = Blockly.JavaScript.valueToCode(
-    block,
-    "Y",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var x = Blockly.JavaScript.valueToCode(
-    block,
-    "X",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var code = "Math.atan2(" + y + ", " + x + ") / Math.PI * 180";
-  return [code, Blockly.JavaScript.ORDER_MULTIPLICATION];
-};
-
-Blockly.Blocks["misc_formatNumber"] = {
-  init: function () {
-    this.setOutput(true, "String");
-    this.appendDummyInput()
-      .appendField("call")
-      .appendField(createNonEditableField("formatNumber"));
-    this.appendValueInput("NUMBER")
-      .setCheck("Number")
-      .appendField("number")
-      .setAlign(Blockly.ALIGN_RIGHT);
-    this.appendValueInput("PRECISION")
-      .setCheck("Number")
-      .appendField("precision")
-      .setAlign(Blockly.ALIGN_RIGHT);
-    this.setColour(functionColor);
-    this.setTooltip(
-      "Returns a text value of the given number formatted with the given precision, padded with zeros if necessary."
-    );
-    this.getJavaScriptInputType = function (inputName) {
-      switch (inputName) {
-        case "NUMBER":
-          return "double";
-        case "PRECISION":
-          return "int";
-        default:
-          return "";
-      }
-    };
-  },
-};
-
-Blockly.JavaScript["misc_formatNumber"] = function (block) {
-  var number = Blockly.JavaScript.valueToCode(
-    block,
-    "NUMBER",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var precision = Blockly.JavaScript.valueToCode(
-    block,
-    "PRECISION",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var code =
-    miscIdentifierForJavaScript +
-    ".formatNumber(" +
-    number +
-    ", " +
-    precision +
-    ")";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
-Blockly.JavaScript["misc_formatNumber"] = function (block) {
-  var number = Blockly.JavaScript.valueToCode(
-    block,
-    "NUMBER",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var precision = Blockly.JavaScript.valueToCode(
-    block,
-    "PRECISION",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  // Due to issues with floating point precision, we always call the JavaUtil method.
-  Blockly.JavaScript.generateImport_("JavaUtil");
-  var code = "JavaUtil.formatNumber(" + number + ", " + precision + ")";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
-Blockly.Blocks["misc_roundDecimal"] = {
-  init: function () {
-    this.setOutput(true, "Number");
-    this.appendDummyInput()
-      .appendField("call")
-      .appendField(createNonEditableField("roundDecimal"));
-    this.appendValueInput("NUMBER")
-      .setCheck("Number")
-      .appendField("number")
-      .setAlign(Blockly.ALIGN_RIGHT);
-    this.appendValueInput("PRECISION")
-      .setCheck("Number")
-      .appendField("precision")
-      .setAlign(Blockly.ALIGN_RIGHT);
-    this.setColour(functionColor);
-    this.setTooltip(
-      "Returns a numeric value of the given number rounded to the given precision."
-    );
-    this.getJavaScriptInputType = function (inputName) {
-      switch (inputName) {
-        case "NUMBER":
-          return "double";
-        case "PRECISION":
-          return "int";
-        default:
-          return "";
-      }
-    };
-  },
-};
-
-Blockly.JavaScript["misc_roundDecimal"] = function (block) {
-  var number = Blockly.JavaScript.valueToCode(
-    block,
-    "NUMBER",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var precision = Blockly.JavaScript.valueToCode(
-    block,
-    "PRECISION",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var code =
-    miscIdentifierForJavaScript +
-    ".roundDecimal(" +
-    number +
-    ", " +
-    precision +
-    ")";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
-Blockly.JavaScript["misc_roundDecimal"] = function (block) {
-  var number = Blockly.JavaScript.valueToCode(
-    block,
-    "NUMBER",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  var precision = Blockly.JavaScript.valueToCode(
-    block,
-    "PRECISION",
-    Blockly.JavaScript.ORDER_COMMA
-  );
-  // Due to issues with floating point precision, we always call the JavaUtil method.
-  Blockly.JavaScript.generateImport_("JavaUtil");
-  var code =
-    "Double.parseDouble(JavaUtil.formatNumber(" +
-    number +
-    ", " +
-    precision +
-    "))";
-  return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
-};
-
 Blockly.Blocks["misc_addItemToList"] = {
   init: function () {
     this.appendDummyInput().appendField("add item");
@@ -360,18 +172,4 @@ Blockly.JavaScript["misc_addItemToList"] = function (block) {
     Blockly.JavaScript.ORDER_MEMBER
   );
   return list + ".push(" + item + ")";
-};
-
-Blockly.JavaScript["misc_addItemToList"] = function (block) {
-  var item = Blockly.JavaScript.valueToCode(
-    block,
-    "ITEM",
-    Blockly.JavaScript.ORDER_NONE
-  );
-  var list = Blockly.JavaScript.valueToCode(
-    block,
-    "LIST",
-    Blockly.JavaScript.ORDER_MEMBER
-  );
-  return list + ".add(" + item + ")";
 };

--- a/src/BlocklyInterface/robotblocks/general/GeneralSection.tsx
+++ b/src/BlocklyInterface/robotblocks/general/GeneralSection.tsx
@@ -349,30 +349,6 @@ export default (() => {
         <block type="comment">
             <field name="COMMENT">Enter your comment here!</field>
         </block>
-        <block type="misc_roundDecimal">
-            <value name="NUMBER">
-                <shadow type="math_number">
-                    <field name="NUM">3.14159265</field>
-                </shadow>
-            </value>
-            <value name="PRECISION">
-                <shadow type="math_number">
-                    <field name="NUM">2</field>
-                </shadow>
-            </value>
-        </block>
-        <block type="misc_formatNumber">
-            <value name="NUMBER">
-                <shadow type="math_number">
-                    <field name="NUM">3.14159265</field>
-                </shadow>
-            </value>
-            <value name="PRECISION">
-                <shadow type="math_number">
-                    <field name="NUM">2</field>
-                </shadow>
-            </value>
-        </block>
         <block type="misc_null"></block>
         <block type="misc_isNull"></block>
         <block type="misc_isNotNull"></block>

--- a/src/BlocklyInterface/robotblocks/general/GeneralSection.tsx
+++ b/src/BlocklyInterface/robotblocks/general/GeneralSection.tsx
@@ -1,0 +1,381 @@
+import "./GeneralBlocks";
+
+export default (() => {
+  return `
+    <!-- Logic is from blockly/demos/code/index.html, with some modification. -->
+    <category name="Logic" colour="210">
+        <block type="controls_if"></block>
+        <block type="controls_if">
+            <mutation else="1"></mutation>
+        </block>
+        <block type="controls_if">
+            <mutation elseif="1" else="1"></mutation>
+        </block>
+        <block type="logic_compare"></block>
+        <block type="logic_operation"></block>
+        <block type="logic_negate"></block>
+        <block type="logic_boolean"></block>
+        <block type="logic_null"></block>
+        <block type="logic_ternary"></block>
+    </category>
+    <!-- Loops is from blockly/demos/code/index.html -->
+    <category name="Loops" colour="120">
+        <block type="controls_repeat_ext">
+            <value name="TIMES">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="controls_whileUntil"></block>
+        <block type="controls_for">
+            <value name="FROM">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="TO">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+            <value name="BY">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="controls_forEach"></block>
+        <block type="controls_flow_statements"></block>
+    </category>
+    <!-- Math is from blockly/demos/code/index.html, with some modifications -->
+    <category name="Math" colour="230">
+        <block type="math_number"></block>
+        <block type="math_arithmetic">
+            <field name="OP">ADD</field>
+            <value name="A">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="B">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_arithmetic">
+            <field name="OP">MINUS</field>
+            <value name="A">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="B">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_arithmetic">
+            <field name="OP">MULTIPLY</field>
+            <value name="A">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="B">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_arithmetic">
+            <field name="OP">DIVIDE</field>
+            <value name="A">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="B">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_arithmetic">
+            <field name="OP">POWER</field>
+            <value name="A">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="B">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_single">
+            <field name="OP">NEG</field>
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">9</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_single">
+            <field name="OP">ABS</field>
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">9</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_single">
+            <field name="OP">ROOT</field>
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">9</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_trig">
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">45</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="misc_atan2">
+            <value name="Y">
+                <shadow type="math_number">
+                    <field name="NUM">20</field>
+                </shadow>
+            </value>
+            <value name="X">
+                <shadow type="math_number">
+                    <field name="NUM">20</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_constant"></block>
+        <block type="math_number_property">
+            <value name="NUMBER_TO_CHECK">
+                <shadow type="math_number">
+                    <field name="NUM">0</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_round">
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">3.1</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_on_list"></block>
+        <block type="math_modulo">
+            <value name="DIVIDEND">
+                <shadow type="math_number">
+                    <field name="NUM">64</field>
+                </shadow>
+            </value>
+            <value name="DIVISOR">
+                <shadow type="math_number">
+                    <field name="NUM">10</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_constrain">
+            <value name="VALUE">
+                <shadow type="math_number">
+                    <field name="NUM">50</field>
+                </shadow>
+            </value>
+            <value name="LOW">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="HIGH">
+                <shadow type="math_number">
+                    <field name="NUM">100</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_random_int">
+            <value name="FROM">
+                <shadow type="math_number">
+                    <field name="NUM">1</field>
+                </shadow>
+            </value>
+            <value name="TO">
+                <shadow type="math_number">
+                    <field name="NUM">100</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="math_random_float"></block>
+    </category>
+    <!-- Text is from blockly/demos/code/index.html, with some modifications -->
+    <category name="Text" colour="160">
+        <block type="text"></block>
+        <block type="text_join"></block>
+        <block type="text_append">
+            <value name="TEXT">
+                <shadow type="text"></shadow>
+            </value>
+        </block>
+        <block type="text_length">
+            <value name="VALUE">
+                <shadow type="text">
+                    <field name="TEXT">abc</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="text_isEmpty">
+            <value name="VALUE">
+                <shadow type="text">
+                    <field name="TEXT"></field>
+                </shadow>
+            </value>
+        </block>
+        <block type="text_indexOf">
+            <value name="VALUE">
+                <block type="variables_get">
+                    <field name="VAR">{textVariable}</field>
+                </block>
+            </value>
+            <value name="FIND">
+                <shadow type="text">
+                    <field name="TEXT">abc</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="text_charAt">
+            <value name="VALUE">
+                <block type="variables_get">
+                    <field name="VAR">{textVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="text_getSubstring">
+            <value name="STRING">
+                <block type="variables_get">
+                    <field name="VAR">{textVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="text_changeCase">
+            <value name="TEXT">
+                <shadow type="text">
+                    <field name="TEXT">abc</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="text_trim">
+            <value name="TEXT">
+                <shadow type="text">
+                    <field name="TEXT">abc</field>
+                </shadow>
+            </value>
+        </block>
+    </category>
+    <!-- Lists is from blockly/demos/code/index.html -->
+    <category name="Lists" colour="260">
+        <block type="lists_create_with">
+            <mutation items="0"></mutation>
+        </block>
+        <block type="lists_create_with"></block>
+        <block type="lists_repeat">
+            <value name="NUM">
+                <shadow type="math_number">
+                    <field name="NUM">5</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="lists_length"></block>
+        <block type="lists_isEmpty"></block>
+        <block type="misc_addItemToList">
+            <value name="LIST">
+                <block type="variables_get">
+                    <field name="VAR">{listVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="lists_indexOf">
+            <value name="VALUE">
+                <block type="variables_get">
+                    <field name="VAR">{listVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="lists_getIndex">
+            <value name="VALUE">
+                <block type="variables_get">
+                    <field name="VAR">{listVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="lists_setIndex">
+            <value name="LIST">
+                <block type="variables_get">
+                    <field name="VAR">{listVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="lists_getSublist">
+            <value name="LIST">
+                <block type="variables_get">
+                    <field name="VAR">{listVariable}</field>
+                </block>
+            </value>
+        </block>
+        <block type="lists_split">
+            <value name="DELIM">
+                <shadow type="text">
+                    <field name="TEXT">,</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="lists_sort"></block>
+    </category>
+    <!-- Variables is from blockly/demos/code/index.html -->
+    <category name="Variables" colour="330" custom="VARIABLE"></category>
+    <!-- Functions is from blockly/demos/code/index.html -->
+    <category name="Functions" colour="290" custom="PROCEDURE"></category>
+    <category name="Miscellaneous" colour="200">
+        <block type="comment">
+            <field name="COMMENT">Enter your comment here!</field>
+        </block>
+        <block type="misc_roundDecimal">
+            <value name="NUMBER">
+                <shadow type="math_number">
+                    <field name="NUM">3.14159265</field>
+                </shadow>
+            </value>
+            <value name="PRECISION">
+                <shadow type="math_number">
+                    <field name="NUM">2</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="misc_formatNumber">
+            <value name="NUMBER">
+                <shadow type="math_number">
+                    <field name="NUM">3.14159265</field>
+                </shadow>
+            </value>
+            <value name="PRECISION">
+                <shadow type="math_number">
+                    <field name="NUM">2</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="misc_null"></block>
+        <block type="misc_isNull"></block>
+        <block type="misc_isNotNull"></block>
+    </category>
+`;
+})();

--- a/src/BlocklyInterface/robotblocks/logic/LogicSection.ts
+++ b/src/BlocklyInterface/robotblocks/logic/LogicSection.ts
@@ -1,8 +1,0 @@
-export default (() => {
-  return `
-<category name="Logic">
-    <block type="controls_if"></block>
-    <block type="logic_compare"></block>
-</category>
-`;
-})();

--- a/src/BlocklyInterface/robotblocks/loops/LoopSection.ts
+++ b/src/BlocklyInterface/robotblocks/loops/LoopSection.ts
@@ -1,7 +1,0 @@
-export default (() => {
-  return `
-<category name="Loops">
-    <block type="controls_repeat_ext"></block>
-</category>
-`;
-})();

--- a/src/BlocklyInterface/robotblocks/math/MathSection.ts
+++ b/src/BlocklyInterface/robotblocks/math/MathSection.ts
@@ -1,7 +1,0 @@
-export default (() => {
-  return `
-<category name="Math">
-    <block type="math_arithmetic"></block>
-</category>
-`;
-})();

--- a/src/BlocklyInterface/toolbox.ts
+++ b/src/BlocklyInterface/toolbox.ts
@@ -1,9 +1,6 @@
 import ActuatorSection from "./robotblocks/actuators/ActuatorSection";
 import SensorSection from "./robotblocks/sensors/SensorSection";
-import LogicSection from "./robotblocks/logic/LogicSection";
-import MathSection from "./robotblocks/math/MathSection";
-import ConstantsSection from "./robotblocks/constants/ConstantsSection";
-import LoopSection from "./robotblocks/loops/LoopSection";
+import GeneralSection from "./robotblocks/general/GeneralSection";
 
 /**
  * Returns the XML for the Toolbox.
@@ -13,9 +10,6 @@ export function getToolbox() {
 <xml>
     ${ActuatorSection}
     ${SensorSection}
-    ${LogicSection}
-    ${MathSection}
-    ${ConstantsSection}
-    ${LoopSection}
+    ${GeneralSection}
 </xml>`;
 }


### PR DESCRIPTION
After spending some time in the FTC blockly implementation, it's becoming clear to me that their blocks won't be importable directly on their own. There's a significant amount of hard-coded calls to Blockly.FtcJava (their Blockly generator), as well as some transpilation from other sources.

However, the general purpose blocks, those that already exist in Blockly land, can just be imported over as they are, so putting in a little PR to cover that and give us some extra basic non-robot-ey blocks while we have a larger think about what robot specific blocks need to be imported over and how best to do that.