### PR TITLE
Halt physics engine instead of re-rendering at program completion

### DIFF
--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -197,7 +197,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             onFinish: () => {
               syncExecutionState(interpreter);
 
-              sim.current?.haltPhysics();
+              sim.current?.setPhysicsActive(false);
 
               dispatch(
                 messageSlice.actions.addMessage({

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -196,7 +196,9 @@ export const VMProvider: FunctionComponent = ({ children }) => {
 
             onFinish: () => {
               syncExecutionState(interpreter);
-              setInterpreter(null);
+
+              sim.current?.haltPhysics();
+
               dispatch(
                 messageSlice.actions.addMessage({
                   type: MessageBarType.success,

--- a/src/RobotSimulator/ChallengeConfigLoader.ts
+++ b/src/RobotSimulator/ChallengeConfigLoader.ts
@@ -123,11 +123,16 @@ function setupBowlingChallenge(): ChallengeConfig {
 function createFinishZoneSpec(
   initialPosition: CoreSimTypes.Vector2d
 ): CoreSpecs.IZoneSpec {
-  let finishZoneSpec: CoreSpecs.IZoneSpec = {
-    type: "zone",
-    zoneId: "finish",
+  const zoneShape: CoreSpecs.IRectangleZoneSpec = {
     xLength: 2,
     zLength: 2,
+    type: "rectangle",
+  };
+
+  const finishZoneSpec: CoreSpecs.IZoneSpec = {
+    type: "zone",
+    zoneId: "finish",
+    zoneShape: zoneShape,
     baseColor: 0x00ff00,
     initialPosition: initialPosition,
   };


### PR DESCRIPTION
Rather than re-rendering the vm/simulator, instead request the sim3d instance to disable its physics. This stops movement of any objects, but allows camera movements for further inspection

For https://github.com/FRUK-Simulator/Simulator/issues/97