### PR TITLE
Keep blockly state when switching tabs

### DIFF
--- a/src/BlocklyInterface/blocklySlice.ts
+++ b/src/BlocklyInterface/blocklySlice.ts
@@ -25,6 +25,9 @@ export const blocklySlice = createSlice({
     /** The id of the blockly program that is currently selected - an empty string
      * designates no selection */
     activeBlocklyProgramId: getPredefinedBlocklyProgs()[0].title,
+    /** The current blockly code inside the 'BlocklyInstance'
+     */
+    blocklyXmlWorkspace: getPredefinedBlocklyProgs()[0].xml,
   },
   name: "blockly",
   reducers: {
@@ -47,6 +50,12 @@ export const blocklySlice = createSlice({
       state.toolboxXml = action.payload.toolboxXml;
 
       return state;
+    },
+    setBlocklyXmlWorkspace(
+      state,
+      action: PayloadAction<{ blocklyXmlWorkspace: string }>
+    ) {
+      state.blocklyXmlWorkspace = action.payload.blocklyXmlWorkspace;
     },
     addBlocklyProgram(state, action: PayloadAction<{ prog: Program }>) {
       // If the program already exists then we update it.
@@ -128,6 +137,9 @@ export const saveBlocklyState = () => {
  */
 export const getHighlightedBlockId = (state: RootState) =>
   state.blockly.highlightedBlock;
+
+export const getBlocklyXmlWorkspace = (state: RootState) =>
+  state.blockly.blocklyXmlWorkspace;
 
 /**
  * Retrieves the previously selected blockly block's ID.

--- a/src/view/hooks/useProgramDialog.tsx
+++ b/src/view/hooks/useProgramDialog.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { getCurrentBlocklyCode } from "../../BlocklyInterface/BlocklyEditor";
+import { getCurrentBlocklyInstanceCode } from "../../BlocklyInterface/BlocklyEditor";
 import { Program } from "../../BlocklyInterface/ProgramExportImport";
 import {
   getCurrentBlocklyProgram,
@@ -122,7 +122,10 @@ export const useProgramDialog = (type: "create" | "save") => {
                 predefined: false,
                 title: programName,
                 description: programDescription,
-                xml: type === "save" ? getCurrentBlocklyCode() : program.xml,
+                xml:
+                  type === "save"
+                    ? getCurrentBlocklyInstanceCode()
+                    : program.xml,
               },
             })
           );

--- a/src/view/views/MyProgramsView.tsx
+++ b/src/view/views/MyProgramsView.tsx
@@ -35,9 +35,23 @@ export const MyProgramsView = () => {
       dispatch(
         blocklySlice.actions.setActiveBlocklyProgramId({ title: program.title })
       );
+
+      // We need to load the blockly XML that is associated with the
+      // selected 'program.title'.
+      for (const entry of programs) {
+        if (entry.title === program.title) {
+          dispatch(
+            blocklySlice.actions.setBlocklyXmlWorkspace({
+              blocklyXmlWorkspace: entry.xml,
+            })
+          );
+          break;
+        }
+      }
+
       history.replace("?view=code");
     },
-    [dispatch, history]
+    [dispatch, history, programs]
   );
 
   const newProgramCallback = useProgramDialog("create");

--- a/src/view/views/SimulatorView.tsx
+++ b/src/view/views/SimulatorView.tsx
@@ -3,7 +3,7 @@ import { Toolbar } from "../components/Toolbar/Toolbar";
 import { Container } from "../components/Common/Container";
 import { RobotSimulator } from "../../RobotSimulator/RobotSimulator";
 import "./SimulatorView.css";
-import { Prompt, useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { BlocklyView } from "./BlocklyView";
 import { useVM } from "../../JavascriptVM/JavascriptVM";
 import { getChallengeFromURL } from "../../RobotSimulator/ChallengeConfigLoader";
@@ -27,22 +27,6 @@ const simulatorViews: Record<SimulatorViews, FunctionComponent> = {
   programs: MyProgramsView,
   settings: SettingsView,
   challenge: ChallengeView,
-};
-
-const WarningPrompt = () => {
-  const currentLocation = useLocation();
-
-  return (
-    <Prompt
-      message={(nextLocation) => {
-        if (nextLocation.pathname !== currentLocation.pathname) {
-          return "Are you sure you want to leave? All unsaved work will be lost.";
-        }
-
-        return true;
-      }}
-    />
-  );
 };
 
 export const LeftPanel = () => {
@@ -87,7 +71,6 @@ export const SimulatorView = () => {
 
   return (
     <div className="simulator-view">
-      <WarningPrompt />
       <LeftPanel />
       <RightPanel />
       <Toolbar />


### PR DESCRIPTION
Store the `BlocklyInstance` state in redux.  Otherwise any unsaved blockly workspace changes are lost whenever the `BlocklyEditor` tab gets unmounted (e.g. when the user switches to a different tab).

Fixes  #115 