### PR TITLE
Optionally fade out display messages (user notifications)

### DIFF
--- a/src/JavascriptVM/ChallengeActionsImpl.ts
+++ b/src/JavascriptVM/ChallengeActionsImpl.ts
@@ -1,6 +1,7 @@
 import { ChallengeActions } from "../RobotSimulator/Arenas/base";
 import { Sim3D, CoreSpecs } from "@fruk/simulator-core";
 import { MessageType, messageSlice } from "../state/messagesSlice";
+import { v4 as uuidv4 } from "uuid";
 
 export class ChallengeActionsImpl implements ChallengeActions {
   constructor(private sim: Sim3D, private dispatch: (a: any) => void) {}
@@ -35,5 +36,32 @@ export class ChallengeActionsImpl implements ChallengeActions {
         msg: message,
       })
     );
+  }
+
+  displayFadingMessage(
+    message: string,
+    type: MessageType,
+    timeout?: number
+  ): void {
+    const msgId = uuidv4();
+    if (!timeout) {
+      timeout = 2000;
+    }
+
+    this.dispatch(
+      messageSlice.actions.addMessage({
+        type,
+        msg: message,
+        id: msgId,
+      })
+    );
+
+    setTimeout(() => {
+      this.dispatch(
+        messageSlice.actions.removeMessage({
+          id: msgId,
+        })
+      );
+    }, timeout);
   }
 }

--- a/src/RobotSimulator/Arenas/base.ts
+++ b/src/RobotSimulator/Arenas/base.ts
@@ -33,6 +33,11 @@ export interface ChallengeActions {
       | CoreSpecs.IZoneSpec
   ): void;
   displayMessage(message: string, type: MessageType): void;
+  displayFadingMessage(
+    message: string,
+    type: MessageType,
+    timeout?: number
+  ): void;
 }
 
 export interface ZoneEvent {

--- a/src/RobotSimulator/Arenas/lesson1.ts
+++ b/src/RobotSimulator/Arenas/lesson1.ts
@@ -224,9 +224,9 @@ class Lesson1Challenge implements ChallengeListener {
   onEvent(e: ChallengeEvent) {
     if (e.kind === "ZoneEvent") {
       if (e.zoneId === FinishZoneId) {
-        this.actions?.displayMessage("Robot Wins!", MessageType.success);
+        this.actions?.displayFadingMessage("Robot Wins!", MessageType.success);
       } else if (e.zoneId.startsWith("bad-")) {
-        this.actions?.displayMessage("Robot Looses!", MessageType.danger);
+        this.actions?.displayFadingMessage("Robot Looses!", MessageType.danger);
       }
     }
   }

--- a/src/state/messagesSlice.ts
+++ b/src/state/messagesSlice.ts
@@ -23,10 +23,14 @@ export const messageSlice = createSlice({
   reducers: {
     addMessage(
       state,
-      action: PayloadAction<{ type: MessageType; msg: string }>
+      action: PayloadAction<{ type: MessageType; msg: string; id?: string }>
     ) {
+      if (!action.payload.id) {
+        action.payload.id = uuidv4();
+      }
+
       state.messages = [
-        { ...action.payload, id: uuidv4() },
+        { ...action.payload, id: action.payload.id },
         ...state.messages,
       ].slice(0, 5);
 


### PR DESCRIPTION
Arenas/lesson1.ts: Make success/failure messages fade away after a configurable amount of time (default 2s)

Extend the `ChallengeActions` interface so that it provides an option to display messages that fade out after a configurable amount of time.

Related to #122