### PR TITLE
Add challenge results display

### DIFF
--- a/src/JavascriptVM/ChallengeActionsImpl.ts
+++ b/src/JavascriptVM/ChallengeActionsImpl.ts
@@ -2,9 +2,17 @@ import { ChallengeActions } from "../RobotSimulator/Arenas/base";
 import { Sim3D, CoreSpecs } from "@fruk/simulator-core";
 import { MessageType, messageSlice } from "../state/messagesSlice";
 import { v4 as uuidv4 } from "uuid";
+import {
+  challengeSlice,
+  ChallengeStatus,
+} from "../RobotSimulator/Arenas/challengeSlice";
 
 export class ChallengeActionsImpl implements ChallengeActions {
-  constructor(private sim: Sim3D, private dispatch: (a: any) => void) {}
+  constructor(
+    private sim: Sim3D,
+    private dispatch: (a: any) => void,
+    private challengeId: string
+  ) {}
 
   addObject(
     o:
@@ -63,5 +71,13 @@ export class ChallengeActionsImpl implements ChallengeActions {
         })
       );
     }, timeout);
+  }
+  setChallengeStatus(status: ChallengeStatus): void {
+    this.dispatch(
+      challengeSlice.actions.setChallengeStatus({
+        status: status,
+        id: this.challengeId,
+      })
+    );
   }
 }

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -32,6 +32,10 @@ import {
 } from "../RobotSimulator/Arenas/base";
 import { ChallengeActionsImpl } from "./ChallengeActionsImpl";
 import { getDefaultChallenge } from "../RobotSimulator/ChallengeConfigLoader";
+import {
+  challengeSlice,
+  ChallengeStatus,
+} from "../RobotSimulator/Arenas/challengeSlice";
 
 /**
  * Interface to control the VM
@@ -310,9 +314,21 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             challengeListener.current.onStop();
           }
 
+          // Before we start the challenge listener we mark the challenge
+          // as pending.  The 'setChallengeStatus' reducer will make sure that if
+          // the challenge is already solved that we won't override the
+          // success state.
+          dispatch(
+            challengeSlice.actions.setChallengeStatus({
+              status: ChallengeStatus.Pending,
+              id: challengeConfig.name,
+            })
+          );
+
           challengeListener.current = challengeConfig.eventListener || null;
           challengeListener.current?.onStart(
-            new ChallengeActionsImpl(simulator, dispatch)
+            // We use the challenge name as the challenge ID
+            new ChallengeActionsImpl(simulator, dispatch, challengeConfig.name)
           );
           this.setCameraView(cameraMode);
         },

--- a/src/RobotSimulator/Arenas/base.ts
+++ b/src/RobotSimulator/Arenas/base.ts
@@ -1,5 +1,6 @@
 import { WorldConfig, CoreSpecs, CoreSimTypes } from "@fruk/simulator-core";
 import { MessageType } from "../../state/messagesSlice";
+import { ChallengeStatus } from "./challengeSlice";
 
 export interface ArenaConfig {
   name: string;
@@ -38,6 +39,7 @@ export interface ChallengeActions {
     type: MessageType,
     timeout?: number
   ): void;
+  setChallengeStatus(status: ChallengeStatus): void;
 }
 
 export interface ZoneEvent {

--- a/src/RobotSimulator/Arenas/challengeSlice.ts
+++ b/src/RobotSimulator/Arenas/challengeSlice.ts
@@ -1,0 +1,57 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../../state/store";
+
+export enum ChallengeStatus {
+  Pending,
+  Failure,
+  Success,
+}
+
+export type ChallengeInfo = {
+  status: ChallengeStatus;
+  id: string;
+};
+
+export const challengeSlice = createSlice({
+  initialState: {
+    challengeInfos: [] as ChallengeInfo[],
+  },
+  name: "challenge",
+  reducers: {
+    setChallengeStatus(
+      state,
+      action: PayloadAction<{ status: ChallengeStatus; id: string }>
+    ) {
+      const challengeIndex = state.challengeInfos.findIndex(
+        (i) => i.id === action.payload.id
+      );
+      // If it's a new challenge, just accept any state that is being set
+      if (challengeIndex === -1) {
+        state.challengeInfos.push({
+          status: action.payload.status,
+          id: action.payload.id,
+        });
+        return state;
+      }
+
+      const currState = state.challengeInfos[challengeIndex].status;
+
+      // If the challenge is already marked as success then do nothing
+      if (currState === ChallengeStatus.Success) return state;
+      if (currState === ChallengeStatus.Failure) {
+        if (action.payload.status === ChallengeStatus.Pending) {
+          state.challengeInfos[challengeIndex].status = ChallengeStatus.Pending;
+        }
+      }
+      // Every transition from Pending is valid
+      else {
+        state.challengeInfos[challengeIndex].status = action.payload.status;
+      }
+
+      return state;
+    },
+  },
+});
+
+export const getChallengeInfo = (state: RootState) =>
+  state.challenge.challengeInfos;

--- a/src/RobotSimulator/Arenas/lesson1.ts
+++ b/src/RobotSimulator/Arenas/lesson1.ts
@@ -8,6 +8,7 @@ import {
 import { MessageType } from "../../state/messagesSlice";
 import { CoreSimTypes } from "@fruk/simulator-core";
 import { CoreSpecs } from "@fruk/simulator-core";
+import { ChallengeStatus } from "./challengeSlice";
 
 export const arenas = [arena];
 export const challenges = [challengeA, challengeB, challengeC];
@@ -225,8 +226,10 @@ class Lesson1Challenge implements ChallengeListener {
     if (e.kind === "ZoneEvent") {
       if (e.zoneId === FinishZoneId) {
         this.actions?.displayFadingMessage("Robot Wins!", MessageType.success);
+        this.actions?.setChallengeStatus(ChallengeStatus.Success);
       } else if (e.zoneId.startsWith("bad-")) {
         this.actions?.displayFadingMessage("Robot Looses!", MessageType.danger);
+        this.actions?.setChallengeStatus(ChallengeStatus.Failure);
       }
     }
   }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -11,6 +11,7 @@ import { messageSlice } from "./messagesSlice";
 import { simulatorLogSlice } from "../ControlPanel/SimulatorLog/simulatorLogSlice";
 import { editorSlice } from "../Editor/editorSlice";
 import { gameControllerSlice } from "./gameControllerSlice";
+import { challengeSlice } from "../RobotSimulator/Arenas/challengeSlice";
 
 // Type Safe Reducers - see https://redux-toolkit.js.org/usage/usage-with-typescript#using-configurestore-with-typescript
 const rootReducer = combineReducers({
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   logs: simulatorLogSlice.reducer,
   editor: editorSlice.reducer,
   gameController: gameControllerSlice.reducer,
+  challenge: challengeSlice.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/view/components/Common/Card.css
+++ b/src/view/components/Common/Card.css
@@ -1,5 +1,5 @@
 :root {
-  --card-width: 20em;
+  --card-width: 21em;
   --card-height: 25em;
 }
 
@@ -21,6 +21,18 @@
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
+.card--title-and-status {
+  display: flex;
+  flex-direction: row;
+  border-color: black;
+}
+
+.card--thumbs {
+  border-color: black;
+  height: "4em";
+  margin-left: 10px;
+  align-self: center;
+}
 .card:hover {
   transform: translate(-2px, 2px);
   box-shadow: -4px 4px 0px -2px var(--primary-color-darkest);

--- a/src/view/views/ChallengeView.tsx
+++ b/src/view/views/ChallengeView.tsx
@@ -8,6 +8,21 @@ import { MarkdownDisplay } from "../components/Common/MarkdownDisplay";
 import { IconName } from "../components/Common/Icon";
 import { LinkButton } from "../components/Common/Button";
 import "./ChallengeView.css";
+import { useSelector } from "react-redux";
+import {
+  ChallengeInfo,
+  ChallengeStatus,
+  getChallengeInfo,
+} from "../../RobotSimulator/Arenas/challengeSlice";
+
+function statusStringRep(info?: ChallengeInfo): string {
+  if (info === undefined) return "Pending";
+
+  const status = info.status;
+  if (status === ChallengeStatus.Pending) return "Pending";
+  else if (status === ChallengeStatus.Success) return "Success";
+  else return "Failure";
+}
 
 export const ChallengeView = () => {
   const { lesson = "", challenge = "" } = useParams<{
@@ -15,6 +30,7 @@ export const ChallengeView = () => {
     challenge: string;
   }>();
 
+  const challengeResults = useSelector(getChallengeInfo);
   const challengeDescriptions = getChallengeFromURL(lesson, challenge)
     ?.descriptions;
   const displayableDescription =
@@ -30,8 +46,13 @@ export const ChallengeView = () => {
         markdown={displayableDescription}
         classes={["challenge-view--content"]}
       />
-      <Divider />
-      <div className="challenge-view--footer">
+      <div className="challenge-view--header">
+        <Title as="h2">
+          {"Challenge Status: " +
+            statusStringRep(challengeResults.find((e) => e.id === challenge))}
+        </Title>
+      </div>
+      <div className="challenge-view--statuster">
         <LinkButton to="/" iconPosition="left" iconName={IconName.back}>
           All Challenges
         </LinkButton>

--- a/src/view/views/LandingView.tsx
+++ b/src/view/views/LandingView.tsx
@@ -10,7 +10,12 @@ import {
 import placeholder from "../components/Header/FIRST_Horz_RGB.png";
 import { Link } from "react-router-dom";
 import { ChallengeConfig } from "../../RobotSimulator/Arenas/base";
-
+import { useSelector } from "react-redux";
+import {
+  ChallengeStatus,
+  getChallengeInfo,
+} from "../../RobotSimulator/Arenas/challengeSlice";
+import { FaThumbsUp, FaThumbsDown } from "react-icons/fa";
 const DEFAULT_LANDING_DESCRIPTION = "Solve this challenge!";
 
 const LessonSection: FunctionComponent<{ title: string }> = ({
@@ -23,6 +28,22 @@ const LessonSection: FunctionComponent<{ title: string }> = ({
       <div className="lessons">{children}</div>
     </div>
   );
+};
+
+export const ChallengeStatusBadge: FunctionComponent<{
+  challengeName: string;
+}> = ({ challengeName }) => {
+  const challengeResults = useSelector(getChallengeInfo);
+  const challengeResult = challengeResults.find(
+    (element) => element.id === challengeName
+  );
+  if (!challengeResult || challengeResult.status === ChallengeStatus.Pending) {
+    return <></>;
+  } else if (challengeResult.status === ChallengeStatus.Failure) {
+    return <FaThumbsDown className="card--thumbs" />;
+  } else {
+    return <FaThumbsUp className="card--thumbs" />;
+  }
 };
 
 export const LandingView = () => {
@@ -50,7 +71,10 @@ export const LandingView = () => {
             >
               <Card>
                 <CardImage src={challenge.image || placeholder} />
-                <CardTitle title={challenge.name} as="h2" />
+                <div className="card--title-and-status">
+                  <CardTitle title={challenge.name} as="h2" />
+                  <ChallengeStatusBadge challengeName={challenge.name} />
+                </div>
                 <CardBody>
                   {challenge.descriptions?.short || DEFAULT_LANDING_DESCRIPTION}
                 </CardBody>


### PR DESCRIPTION
Show the current challenge state in the `LandingView.tsx` and the `ChallengeView` component.

To be able to show the challenge state this commit:
* adds an additional slice, `challengeSlice.ts`, that stores the current state of each challenge.  Challenges can be in one of three states: Pending, Success and Failure.
* Extends the `ChallengeActions` interface to provide lessons an API to mark the current VM run as success/failure.

Closes #114