### PR TITLE
bug fix: Don't loose challenge failure state

### DIFF
--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -314,10 +314,10 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             challengeListener.current.onStop();
           }
 
-          // Before we start the challenge listener we mark the challenge
-          // as pending.  The 'setChallengeStatus' reducer will make sure that if
-          // the challenge is already solved that we won't override the
-          // success state.
+          // Before we start the challenge listener we mark the challenge as
+          // pending.  The 'setChallengeStatus' reducer will make sure that if
+          // the challenge is already solved (or currently marked as failed)
+          // that we won't loose that state.
           dispatch(
             challengeSlice.actions.setChallengeStatus({
               status: ChallengeStatus.Pending,

--- a/src/view/views/LandingView.tsx
+++ b/src/view/views/LandingView.tsx
@@ -39,7 +39,10 @@ export const ChallengeStatusBadge: FunctionComponent<{
   );
   if (!challengeResult || challengeResult.status === ChallengeStatus.Pending) {
     return <></>;
-  } else if (challengeResult.status === ChallengeStatus.Failure) {
+  } else if (
+    challengeResult.status === ChallengeStatus.Failure ||
+    challengeResult.status === ChallengeStatus.Pending_LastRunFailure
+  ) {
     return <FaThumbsDown className="card--thumbs" />;
   } else {
     return <FaThumbsUp className="card--thumbs" />;


### PR DESCRIPTION
Fix a bug that causes the simulator to loose the challenge state of failed challenges.

The bug can be triggered as follows:
1) Open a challenge (say, challenge A) and produce a failure event
2) Go back to the main menu
3) Re-enter challenge A, and then navigate back to landing page
4) => The status of challenge A has been lost

This commit ensures the challenge slice keeps track of past failures.

Admittedly, the change feels a bit too complicated and there's probably a more elegant
solution to track the challenge status.  I thought about some alternatives, but
all of them would involve even more code changes, which does not seem justified.

I think the most natural way to implement the challenge status tracking is via
the `ChallengeActionsImpl` class.  I.e., if we supply the `ChallengeActionsImpl`
constructor with the challenge state when the current robot run starts, then
the `ChallengeActionsImpl` can work out how to update the challenge status
slice, because it also receives the simulation events generated during the
robot run.  However, reading the challenge state from within the `VMProvider`
(which creates the `ChallengeActionsImpl`) has unintended consequences.  When the
`VMProvider` uses a selector to retrieve the challenge status, then the `VMProvider`'s
`setChallenge` method will be re-run whenever the challenge state changes, and
therefore reset the entire simulation when a failure or success event occurs.