### PR TITLE
blockly: add combined motor power set block

### DIFF
--- a/src/BlocklyInterface/robotblocks/actuators/ActuatorSection.ts
+++ b/src/BlocklyInterface/robotblocks/actuators/ActuatorSection.ts
@@ -1,11 +1,14 @@
 import { addMotorBlock } from "./Motor";
+import { addMotorCombinedBlock } from "./MotorCombined";
 
 export default (() => {
   addMotorBlock();
+  addMotorCombinedBlock();
 
   return `
 <category name="Actuators">
     <block type="motor"></block>
+    <block type="motor-combined"></block>
 </category>
 `;
 })();

--- a/src/BlocklyInterface/robotblocks/actuators/MotorCombined.ts
+++ b/src/BlocklyInterface/robotblocks/actuators/MotorCombined.ts
@@ -1,0 +1,81 @@
+import { addCustomBlock, JavaScript } from "../AddBlockUtil";
+
+export function addMotorCombinedBlock() {
+  addCustomBlock(
+    "motor-combined",
+    [
+      {
+        type: "motor-combined",
+        message0:
+          "Motor port %1 direction %2 set power %% %3 %4 Motor port %5 direction %6 set power %% %7",
+        args0: [
+          {
+            type: "field_number",
+            name: "a_port",
+            value: 0,
+            min: 0,
+          },
+          {
+            type: "field_dropdown",
+            name: "a_direction",
+            options: [
+              ["forward", "FORWARD"],
+              ["backward", "BACKWARD"],
+            ],
+          },
+          {
+            type: "input_value",
+            name: "a_power",
+            check: "Number",
+            align: "RIGHT",
+          },
+          { type: "dummy_input" },
+          {
+            type: "field_number",
+            name: "b_port",
+            value: 1,
+            min: 0,
+          },
+          {
+            type: "field_dropdown",
+            name: "b_direction",
+            options: [
+              ["forward", "FORWARD"],
+              ["backward", "BACKWARD"],
+            ],
+          },
+          {
+            type: "input_value",
+            name: "b_power",
+            check: "Number",
+            align: "RIGHT",
+          },
+        ],
+        previousStatement: null,
+        nextStatement: null,
+        colour: 230,
+        tooltip: "",
+        helpUrl: "",
+        inputsInline: false,
+      },
+    ],
+    (block) => {
+      let mot = (prefix: string) => {
+        const numberPort = block.getFieldValue(prefix + "port");
+        const dropdownDirection = block.getFieldValue(prefix + "direction");
+        const valuePower = JavaScript.valueToCode(
+          block,
+          prefix + "power",
+          JavaScript.ORDER_ATOMIC
+        );
+
+        // convert direction to power sign +/-
+        const isForward = dropdownDirection === "FORWARD";
+        const sign = isForward ? "1" : "-1";
+        return `setMotorPower(${numberPort}, ${sign} * (${valuePower}));`;
+      };
+
+      return mot("a_") + "\n" + mot("b_") + "\n";
+    }
+  );
+}


### PR DESCRIPTION
This combined block allows atomically setting power to both motors. 
This is needed to allow the robot to predictably move directly forward or backward on slow execution speeds.
Without this the robot would power one side before the other which would cause the robot to list unhelpfully to one side.

Fixes #144