### PR TITLE
vm: fix early exit on wait

### DIFF
--- a/src/JavascriptVM/vm.ts
+++ b/src/JavascriptVM/vm.ts
@@ -268,7 +268,7 @@ export class BlocklyInterpreter {
   private _step(): boolean {
     let finished = false;
     this.blockHighlighted = false;
-    while (!this.blockHighlighted && !finished) {
+    while (!this.blockHighlighted && this.nextStepDelay === 0 && !finished) {
       finished = !this.interpreter.step();
     }
     this.blockHighlighted = false;


### PR DESCRIPTION
We should exit from running statements if we are supposed to be waiting.
Without this, a program which ends on a:
wait(n); 
will simply exit before waiting.

Fixes #149 