### PR TITLE
Improve success/failure report messages

### DIFF
--- a/src/RobotSimulator/Arenas/lesson1.ts
+++ b/src/RobotSimulator/Arenas/lesson1.ts
@@ -193,10 +193,13 @@ function challengeC(): ChallengeConfig {
 const FinishZoneId = "finish-zone";
 
 class Lesson1Challenge implements ChallengeListener {
+  private challengeOutcomePending: boolean;
   constructor(
     public finishPosition: CoreSimTypes.Vector2d,
     public badZones: CoreSpecs.IZoneSpec[]
-  ) {}
+  ) {
+    this.challengeOutcomePending = true;
+  }
   actions?: ChallengeActions;
 
   onStart(actions: ChallengeActions) {
@@ -216,6 +219,7 @@ class Lesson1Challenge implements ChallengeListener {
       z.zoneId = "bad-" + z.zoneId;
       actions.addObject(z);
     });
+    this.challengeOutcomePending = true;
   }
 
   onStop() {
@@ -224,10 +228,15 @@ class Lesson1Challenge implements ChallengeListener {
 
   onEvent(e: ChallengeEvent) {
     if (e.kind === "ZoneEvent") {
-      if (e.zoneId === FinishZoneId) {
+      if (e.zoneId === FinishZoneId && this.challengeOutcomePending === true) {
+        this.challengeOutcomePending = false;
         this.actions?.displayFadingMessage("Robot Wins!", MessageType.success);
         this.actions?.setChallengeStatus(ChallengeStatus.Success);
-      } else if (e.zoneId.startsWith("bad-")) {
+      } else if (
+        e.zoneId.startsWith("bad-") &&
+        this.challengeOutcomePending === true
+      ) {
+        this.challengeOutcomePending = false;
         this.actions?.displayFadingMessage("Robot Looses!", MessageType.danger);
         this.actions?.setChallengeStatus(ChallengeStatus.Failure);
       }


### PR DESCRIPTION
Relates to https://github.com/FRUK-Simulator/Simulator/issues/153

- Don't emit a 'Robot Wins!' message if the robot has crossed a "bad" zone during the current run.
- Similarly, don't emit a 'Robot Looses!' message if the robot has already reached the 'FinishZoneId' cleanly (i.e. without driving into a bad zone beforehand).

If we are okay with the proposed approach then I can apply this to the other lessons.