### PR TITLE
remove illegal import from blocklySlice

### DIFF
--- a/src/BlocklyInterface/blocklySlice.ts
+++ b/src/BlocklyInterface/blocklySlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { RootState, store } from "../state/store";
+import { RootState } from "../state/store";
 import { vmSlice } from "../JavascriptVM/vmSlice";
 import { ExecutionState } from "../JavascriptVM/vm";
 import { getDefaultToolbox } from "./toolbox";
@@ -121,9 +121,9 @@ export const loadBlocklyState = () => {
   }
 };
 
-export const saveBlocklyState = () => {
+export const saveBlocklyState = (state: RootState) => {
   try {
-    const serializedState = JSON.stringify(store.getState().blockly);
+    const serializedState = JSON.stringify(state.blockly);
     localStorage.setItem(localStorageKey, serializedState);
   } catch {}
 };

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -35,7 +35,7 @@ export const store = configureStore({
   },
 });
 
-store.subscribe(saveBlocklyState);
+store.subscribe(() => saveBlocklyState(store.getState()));
 
 // Dispatch Type - See https://redux-toolkit.js.org/usage/usage-with-typescript#getting-the-dispatch-type
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
This import was causing a circular dependency since store imports blocklySlice

During the import process, we are not allowed to use any of the values
exported from the modules in the import path.