### PR TITLE
clear remaining delay

### DIFF
--- a/src/JavascriptVM/vm.ts
+++ b/src/JavascriptVM/vm.ts
@@ -317,10 +317,13 @@ export class BlocklyInterpreter {
   private _run(steps: number) {
     let timeout = this.executionInterval;
 
+    // Incorperate any pending delay `nextStepDelay` into the timeout
     if (this.nextStepDelay > this.executionInterval) {
       timeout = this.nextStepDelay;
-      this.nextStepDelay = 0;
     }
+
+    // Clear the remaining delay for the next execution
+    this.nextStepDelay = 0;
 
     setTimeout(() => {
       // do not schedule any more work if stopped


### PR DESCRIPTION
otherwise the delay will be ever present if smaller than the execution interval

fixes #176 