### PR TITLE
Add limit to number of blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/marked": "^1.1.0",
         "@types/react-syntax-highlighter": "^11.0.5",
         "@uifabric/icons": "^7.5.23",
-        "blockly": "^3.20200924.4",
+        "blockly": "^6.20210701.0",
         "js-interpreter": "^2.3.0",
         "marked": "^2.0.3",
         "normalize.css": "^8.0.1",
@@ -5751,11 +5751,11 @@
       }
     },
     "node_modules/blockly": {
-      "version": "3.20200924.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.4.tgz",
-      "integrity": "sha512-KDPVLJSguxwKXL6GVdVaYRINoxtojTsQ4lOhuWS9LkzyMhmQVZKMgFzlQum5rE5+hlhzj1BqqUQHe8JbfvL+dQ==",
+      "version": "6.20210701.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-6.20210701.0.tgz",
+      "integrity": "sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==",
       "dependencies": {
-        "jsdom": "^15.2.1"
+        "jsdom": "15.2.1"
       }
     },
     "node_modules/bluebird": {
@@ -30052,11 +30052,11 @@
       }
     },
     "blockly": {
-      "version": "3.20200924.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.4.tgz",
-      "integrity": "sha512-KDPVLJSguxwKXL6GVdVaYRINoxtojTsQ4lOhuWS9LkzyMhmQVZKMgFzlQum5rE5+hlhzj1BqqUQHe8JbfvL+dQ==",
+      "version": "6.20210701.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-6.20210701.0.tgz",
+      "integrity": "sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==",
       "requires": {
-        "jsdom": "^15.2.1"
+        "jsdom": "15.2.1"
       }
     },
     "bluebird": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@types/marked": "^1.1.0",
     "@types/react-syntax-highlighter": "^11.0.5",
     "@uifabric/icons": "^7.5.23",
-    "blockly": "^3.20200924.4",
+    "blockly": "^6.20210701.0",
     "js-interpreter": "^2.3.0",
     "marked": "^2.0.3",
     "normalize.css": "^8.0.1",

--- a/src/BlocklyInterface/BlocklyInstance.ts
+++ b/src/BlocklyInterface/BlocklyInstance.ts
@@ -9,11 +9,15 @@ export class BlocklyUiEvent extends Events.Ui {
 export type BlocklyEvent =
   | Events.BlockChange
   | Events.BlockMove
+  | Events.Create
+  | Events.Delete
   | BlocklyUiEvent;
 
 export enum BlocklyEventName {
   BlockChange = "BlockChange",
   BlockMove = "BlockMove",
+  BlockCreate = "BlockCreate",
+  BlockDelete = "BlockDelete",
   Ui = "Ui",
 }
 
@@ -67,6 +71,14 @@ class BlocklyInstance {
 
   highlightBlock(id: string) {
     return this.workspace.highlightBlock(id);
+  }
+
+  setMaxBlocks(maxBlocks: number) {
+    this.workspace.options.maxBlocks = maxBlocks;
+  }
+
+  clearMaxBlocks() {
+    this.workspace.options.maxBlocks = Infinity;
   }
 
   addChangeListener(

--- a/src/BlocklyInterface/blocklySlice.ts
+++ b/src/BlocklyInterface/blocklySlice.ts
@@ -5,6 +5,7 @@ import { ExecutionState } from "../JavascriptVM/vm";
 import { getDefaultToolbox } from "./toolbox";
 import { getPredefinedBlocklyProgs } from "../core/blockly/programs";
 import { Program } from "./ProgramExportImport";
+import { MaxBlockConfig as MaxBlocksConfig } from "../RobotSimulator/Arenas/base";
 
 /**
  * Reducers for handling the state of the blockly interface such as which blocks are highlighted.
@@ -28,6 +29,11 @@ export const blocklySlice = createSlice({
     /** The current blockly code inside the 'BlocklyInstance'
      */
     blocklyXmlWorkspace: getPredefinedBlocklyProgs()[0].xml,
+
+    /**
+     * Config the maximum block the student can/should use.
+     */
+    maxBlocksConfig: undefined as MaxBlocksConfig | undefined,
   },
   name: "blockly",
   reducers: {
@@ -86,6 +92,13 @@ export const blocklySlice = createSlice({
     },
     setActiveBlocklyProgramId(state, action: PayloadAction<{ title: string }>) {
       state.activeBlocklyProgramId = action.payload.title;
+      return state;
+    },
+    setMaxBlocksConfig(
+      state,
+      action: PayloadAction<{ maxBlocksConfig?: MaxBlocksConfig }>
+    ) {
+      state.maxBlocksConfig = action.payload.maxBlocksConfig;
       return state;
     },
   },
@@ -208,3 +221,6 @@ export const getCurrentBlocklyProgram = (state: RootState) =>
  */
 export const getBlocklyProgram = (title: string) => (state: RootState) =>
   state.blockly.blocklyPrograms.find((p) => p.title === title);
+
+export const getMaxBlocksConfig = (state: RootState) =>
+  state.blockly.maxBlocksConfig;

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -351,6 +351,12 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             })
           );
 
+          dispatch(
+            blocklySlice.actions.setMaxBlocksConfig({
+              maxBlocksConfig: challengeConfig.maxBlocksConfig,
+            })
+          );
+
           challengeListener.current = challengeConfig.eventListener || null;
           challengeListener.current?.onStart(
             // We use the challenge name as the challenge ID

--- a/src/RobotSimulator/Arenas/base.ts
+++ b/src/RobotSimulator/Arenas/base.ts
@@ -16,6 +16,21 @@ interface ChallengeDescription {
   markdown?: string;
 }
 
+export interface MaxBlockConfig {
+  /**
+   * The maximum number of blocks the student can/should use.
+   */
+  maxBlocks: number;
+
+  /**
+   * Whether the limit is hard or soft.
+   *
+   * Hard limit block the student from adding more than maxBlocks.
+   * Soft limit just let the user know they should use that many blocks.
+   */
+  isHardLimit: boolean;
+}
+
 export interface ChallengeConfig {
   name: string;
   startPosition: CoreSimTypes.Vector2d;
@@ -23,6 +38,7 @@ export interface ChallengeConfig {
   eventListener?: ChallengeListener;
   descriptions?: ChallengeDescription;
   image?: any;
+  maxBlocksConfig?: MaxBlockConfig;
 }
 
 // interface to trigger actions and events in the current challenge.

--- a/src/RobotSimulator/Arenas/lesson1.ts
+++ b/src/RobotSimulator/Arenas/lesson1.ts
@@ -67,6 +67,10 @@ function challengeA(): ChallengeConfig {
     name: "Lesson 1 - Challenge A",
     startPosition: { x: 0, y: 2 },
     arenaConfig: arena(),
+    maxBlocksConfig: {
+      maxBlocks: 6,
+      isHardLimit: false,
+    },
     eventListener: new Lesson1Challenge({ x: 0, y: -2 }, badZones),
     descriptions: {
       short: "Using the motors",
@@ -103,6 +107,10 @@ function challengeB(): ChallengeConfig {
     name: "Lesson 1 - Challenge B",
     startPosition: { x: -2, y: 2 },
     arenaConfig: arena(),
+    maxBlocksConfig: {
+      maxBlocks: 6,
+      isHardLimit: false,
+    },
     eventListener: new Lesson1Challenge({ x: +2, y: 2 }, badZones),
     descriptions: {
       short: "Using the motors to turn a corner",
@@ -163,6 +171,10 @@ function challengeC(): ChallengeConfig {
     name: "Lesson 1 - Challenge C",
     startPosition: { x: -2, y: 2 },
     arenaConfig: arena(),
+    maxBlocksConfig: {
+      maxBlocks: 6,
+      isHardLimit: false,
+    },
     eventListener: new Lesson1Challenge({ x: 2, y: 2 }, badZones),
     descriptions: {
       short: "Using the motors to turn precise angles",

--- a/src/view/views/SimulatorView.tsx
+++ b/src/view/views/SimulatorView.tsx
@@ -59,7 +59,8 @@ export const SimulatorView = () => {
 
   useEffect(
     function loadChallengeFromURL() {
-      vm.setChallenge(getChallengeFromURL(lesson, challenge));
+      const challangeConfig = getChallengeFromURL(lesson, challenge);
+      vm.setChallenge(challangeConfig);
     },
     [lesson, challenge, vm]
   );


### PR DESCRIPTION
Fix #92 by allow challange config to specify the number of blocks allowed
to be used. This should help students to identify the are on the wrong
path but it seems like a clear feedback of how many blocks are allowed
is required as blockly simply turn all blocks into "disabled" without
clear explanation why that is.