### PR TITLE
Pause the simulation when 'Pause' button is clicked

### DIFF
--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -232,6 +232,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
+          sim.current?.setPhysicsActive(true);
           interpreter.run();
           syncExecutionState(interpreter);
         },
@@ -241,6 +242,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
+          sim.current?.setPhysicsActive(false);
           interpreter.pause();
           syncExecutionState(interpreter);
         },
@@ -250,6 +252,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
+          sim.current?.setPhysicsActive(true);
           interpreter?.step();
           syncExecutionState(interpreter);
         },

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -232,7 +232,6 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
-          sim.current?.setPhysicsActive(true);
           interpreter.run();
           syncExecutionState(interpreter);
         },
@@ -242,7 +241,6 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
-          sim.current?.setPhysicsActive(false);
           interpreter.pause();
           syncExecutionState(interpreter);
         },
@@ -252,7 +250,6 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             return;
           }
 
-          sim.current?.setPhysicsActive(true);
           interpreter?.step();
           syncExecutionState(interpreter);
         },
@@ -309,6 +306,15 @@ export const VMProvider: FunctionComponent = ({ children }) => {
             onControllerKeyCheck: (key: ControllerKey): boolean => {
               return getControllerKeys(store.getState())[key];
             },
+
+            onPause: () => {
+              sim.current?.setPhysicsActive(false);
+            },
+
+            onUnPause: () => {
+              sim.current?.setPhysicsActive(true);
+            },
+
             getSensorValue: (channel: number): number => {
               const value = robotRef.current?.getAnalogInput(channel);
               if (value) {

--- a/src/JavascriptVM/vm.ts
+++ b/src/JavascriptVM/vm.ts
@@ -37,6 +37,16 @@ export type BlocklyInterpreterCallbacks = {
   onControllerKeyCheck?: (key: ControllerKey) => boolean;
 
   /**
+   * Called when the simulation is supposed to be paused therefore stop all physics
+   */
+  onPause?: () => void;
+
+  /**
+   * Called when the simulation is supposed to resume from pause therefore start all physics
+   */
+  onUnPause?: () => void;
+
+  /**
    * Gets the value of the given sensor on the curent robot. value is between 0.0 and 1.0.
    */
   getSensorValue?: (port: number) => number;
@@ -278,6 +288,7 @@ export class BlocklyInterpreter {
   private _step(): boolean {
     let finished = false;
     this.blockHighlighted = false;
+    this.callbacks.onUnPause && this.callbacks.onUnPause();
     while (!this.blockHighlighted && this.nextStepDelay === 0 && !finished) {
       finished = !this.interpreter.step();
     }
@@ -362,6 +373,7 @@ export class BlocklyInterpreter {
   pause() {
     if (this.executionState === ExecutionState.RUNNING) {
       this.executionState = ExecutionState.PAUSED;
+      this.callbacks.onPause && this.callbacks.onPause();
     }
   }
 
@@ -371,6 +383,7 @@ export class BlocklyInterpreter {
   unpause() {
     if (this.executionState === ExecutionState.PAUSED) {
       this.executionState = ExecutionState.RUNNING;
+      this.callbacks.onUnPause && this.callbacks.onUnPause();
     }
   }
 


### PR DESCRIPTION
This is part of the https://github.com/FRUK-Simulator/Simulator/issues/215
The physical world is not paused when pause button is hit. This PR is to make the arena freeze when paused. When the timer feature is done we can make sure both timer and the arena are paused.