### PR TITLE
Add the ability to configure whether robot has a distance sensor

### DIFF
--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -383,7 +383,10 @@ export const VMProvider: FunctionComponent = ({ children }) => {
 
           const { robot, robotSpec } = new StdWorldBuilder(
             simulator,
-            challengeConfig.startPosition
+            challengeConfig.startPosition,
+            challengeConfig.robotConfig
+              ? challengeConfig.robotConfig.disableDistanceSensor
+              : false
           ).build();
 
           robotRef.current = new Proxy(robot!, robot_handler);

--- a/src/RobotSimulator/Arenas/base.ts
+++ b/src/RobotSimulator/Arenas/base.ts
@@ -31,6 +31,10 @@ export interface MaxBlockConfig {
   isHardLimit: boolean;
 }
 
+export interface RobotConfig {
+  disableDistanceSensor: boolean;
+}
+
 export interface ChallengeConfig {
   name: string;
   startPosition: CoreSimTypes.Vector2d;
@@ -39,6 +43,7 @@ export interface ChallengeConfig {
   descriptions?: ChallengeDescription;
   image?: any;
   maxBlocksConfig?: MaxBlockConfig;
+  robotConfig?: RobotConfig;
 }
 
 // interface to trigger actions and events in the current challenge.

--- a/src/RobotSimulator/Arenas/lesson4.ts
+++ b/src/RobotSimulator/Arenas/lesson4.ts
@@ -121,6 +121,7 @@ function challengeA(): ChallengeConfig {
   start again.
         `,
     },
+    robotConfig: { disableDistanceSensor: true },
   };
 
   return challengeConfig;
@@ -219,6 +220,7 @@ function challengeB(): ChallengeConfig {
   start again.
         `,
     },
+    robotConfig: { disableDistanceSensor: true },
   };
 
   return challengeConfig;
@@ -349,6 +351,7 @@ function challengeC(): ChallengeConfig {
   start again.
         `,
     },
+    robotConfig: { disableDistanceSensor: true },
   };
 
   return challengeConfig;

--- a/src/RobotSimulator/StdWorldBuilder.ts
+++ b/src/RobotSimulator/StdWorldBuilder.ts
@@ -8,10 +8,16 @@ import { DISTANCE_SENSOR_RANGE } from "../JavascriptVM/distanceSensorConstants";
 export class StdWorldBuilder {
   private sim3D: Sim3D;
   private startPosition: CoreSimTypes.Vector2d;
+  private disableDistanceSensor: boolean;
 
-  constructor(sim3D: Sim3D, startPosition: CoreSimTypes.Vector2d) {
+  constructor(
+    sim3D: Sim3D,
+    startPosition: CoreSimTypes.Vector2d,
+    disableDistanceSensor?: boolean
+  ) {
     this.sim3D = sim3D;
     this.startPosition = startPosition;
+    this.disableDistanceSensor = disableDistanceSensor ?? false;
   }
 
   build = (): {
@@ -25,11 +31,13 @@ export class StdWorldBuilder {
 
     {
       // Sensors
-      const distanceSensor = new RobotBuilder.DistanceSensorBuilder(0);
-      distanceSensor.setMountFace(RobotSpecs.SensorMountingFace.FRONT);
-      distanceSensor.setMaxRange(DISTANCE_SENSOR_RANGE);
+      if (!this.disableDistanceSensor) {
+        const distanceSensor = new RobotBuilder.DistanceSensorBuilder(0);
+        distanceSensor.setMountFace(RobotSpecs.SensorMountingFace.FRONT);
+        distanceSensor.setMaxRange(DISTANCE_SENSOR_RANGE);
 
-      robotBuilder.addBasicSensor(distanceSensor);
+        robotBuilder.addBasicSensor(distanceSensor);
+      }
 
       const colorSensor = new RobotBuilder.ColorSensorBuilder(1);
       colorSensor.setMountFace(RobotSpecs.SensorMountingFace.BOTTOM);


### PR DESCRIPTION
Lessons 4 need to have the distance sensor disabled, so we're exposing robot configuration as part of challenge configuration. 

Let me know if we want to tie the robot configuration in with the arena configuration as originally intended, it made more sense to me to make it a separate config.

Closes #244 