### PR TITLE
Show motors from robot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fluentui/react": "^7.168.2",
-        "@fruk/simulator-core": "^1.8.9",
+        "@fruk/simulator-core": "1.8.11",
         "@reduxjs/toolkit": "^1.7.1",
         "@types/marked": "^1.1.0",
         "@types/react-syntax-highlighter": "^11.0.5",
@@ -2181,14 +2181,14 @@
       }
     },
     "node_modules/@fruk/simulator-core": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/@fruk/simulator-core/-/simulator-core-1.8.10.tgz",
-      "integrity": "sha512-a8VVIOtrNr3JaGpBZWajN9F2a4ryCVL5klNJrwXrvnWoDSnBOo67TI3hM1eS8sWQe4zlgUqebX4q4o2DjXOdNg==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@fruk/simulator-core/-/simulator-core-1.8.11.tgz",
+      "integrity": "sha512-F8bs+xY6b76UBfJ4DIvuUirFXjW2zcqpGJV5M5jBmdLT+BNDyI0q1sTTV03aF83NujBpD1lju5SZHeDXdB3qsQ==",
       "dependencies": {
         "@types/three": "^0.x",
         "planck-js": "^0.3.x",
         "stats.js": "^0.17.x",
-        "three": "^0.x",
+        "three": "0.136.0",
         "uuid": "^8.3.x"
       }
     },
@@ -21108,14 +21108,14 @@
       }
     },
     "@fruk/simulator-core": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/@fruk/simulator-core/-/simulator-core-1.8.10.tgz",
-      "integrity": "sha512-a8VVIOtrNr3JaGpBZWajN9F2a4ryCVL5klNJrwXrvnWoDSnBOo67TI3hM1eS8sWQe4zlgUqebX4q4o2DjXOdNg==",
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@fruk/simulator-core/-/simulator-core-1.8.11.tgz",
+      "integrity": "sha512-F8bs+xY6b76UBfJ4DIvuUirFXjW2zcqpGJV5M5jBmdLT+BNDyI0q1sTTV03aF83NujBpD1lju5SZHeDXdB3qsQ==",
       "requires": {
         "@types/three": "^0.x",
         "planck-js": "^0.3.x",
         "stats.js": "^0.17.x",
-        "three": "^0.x",
+        "three": "0.136.0",
         "uuid": "^8.3.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@fluentui/react": "^7.168.2",
-    "@fruk/simulator-core": "^1.8.10",
+    "@fruk/simulator-core": "1.8.11",
     "@reduxjs/toolkit": "^1.7.1",
     "@types/marked": "^1.1.0",
     "@types/react-syntax-highlighter": "^11.0.5",

--- a/src/JavascriptVM/JavascriptVM.tsx
+++ b/src/JavascriptVM/JavascriptVM.tsx
@@ -101,26 +101,6 @@ export const VMProvider: FunctionComponent = ({ children }) => {
 
   const store = useStore();
 
-  // handler for robot handlers, all calls to setMotorPower will update state in redux
-  const robot_handler: ProxyHandler<Handles.RobotHandle> = {
-    get: function (target, property, receiver) {
-      if (property === "setMotorPower") {
-        const originalImpl = target[property];
-        return function (channel: number, power: number) {
-          dispatch(
-            robotSimulatorSlice.actions.setPower({
-              channel: channel,
-              power: power,
-            })
-          );
-          return originalImpl.apply(target, [channel, power]);
-        };
-      }
-
-      return Reflect.get(target, property, receiver);
-    },
-  };
-
   /**
    * Syncs the redux state with the interpreter state.
    */
@@ -402,7 +382,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
               : false
           ).build();
 
-          robotRef.current = new Proxy(robot!, robot_handler);
+          robotRef.current = robot!;
 
           arena.ballSpecs?.forEach(function (ballSpec) {
             simulator.addBall(ballSpec);
@@ -478,7 +458,7 @@ export const VMProvider: FunctionComponent = ({ children }) => {
           );
 
           sim.current.beginRendering();
-          robotRef.current = new Proxy(robot!, robot_handler);
+          robotRef.current = robot!;
           sim.current?.addListener(
             "simulation-event",
             (event: CoreSpecs.ISimulatorEvent) => {

--- a/src/RobotSimulator/StdWorldBuilder.ts
+++ b/src/RobotSimulator/StdWorldBuilder.ts
@@ -78,13 +78,13 @@ export class StdWorldBuilder {
 
     {
       // Motors
-      const motor = new RobotBuilder.MotorBuilder();
-      motor.setMaxForce(0.25);
+      const motorBuilder = new RobotBuilder.MotorBuilder();
+      motorBuilder.setMaxForce(0.25);
 
-      const leftMotors = motor.copy();
+      const leftMotors = motorBuilder.copy();
       leftMotors.setChannel(0);
 
-      const rightMotors = motor.copy();
+      const rightMotors = motorBuilder.copy();
       rightMotors.setChannel(1);
 
       robotBuilder.addMotor("left-drive", leftMotors);

--- a/src/RobotSimulator/robotSimulatorSlice.ts
+++ b/src/RobotSimulator/robotSimulatorSlice.ts
@@ -17,6 +17,7 @@ export interface Sensors {
   contactSensors: Sensor[];
   gyroscopeSensors: Sensor[];
   colorSensors: Sensor[];
+  motors: Sensor[];
 }
 
 interface IRobotSimulatorState {
@@ -37,6 +38,7 @@ export const robotSimulatorSlice = createSlice({
       contactSensors: [],
       gyroscopeSensors: [],
       colorSensors: [],
+      motors: [],
     },
   } as IRobotSimulatorState,
   name: "simulator",
@@ -73,11 +75,22 @@ export function specToSensors(spec: IRobotSpec): Sensors {
     };
   };
 
+  const motors: Sensor[] = [];
+  spec.drivetrain.motorGroups.forEach((motorGroup) => {
+    motorGroup.motors.forEach((motor) => {
+      motors.push({
+        channel: motor.channel,
+        mountFaceName: motorGroup.wheelGroup,
+      });
+    });
+  });
+
   return {
     distanceSensors: spec.basicSensors?.filter(isDist).map(convertToObj) || [],
     contactSensors:
       spec.basicSensors?.filter(isContact).map(convertToObj) || [],
     gyroscopeSensors: spec.basicSensors?.filter(isGyro).map(convertToObj) || [],
     colorSensors: spec.complexSensors?.filter(isColor).map(convertToObj) || [],
+    motors,
   };
 }

--- a/src/view/views/RobotView.tsx
+++ b/src/view/views/RobotView.tsx
@@ -1,24 +1,39 @@
 import React from "react";
+import { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
+import { getExecutionState } from "../../JavascriptVM/vmSlice";
+import { ExecutionState } from "../../JavascriptVM/vm";
 import { DISTANCE_SENSOR_RANGE } from "../../JavascriptVM/distanceSensorConstants";
 import { useVM } from "../../JavascriptVM/JavascriptVM";
-import {
-  getMotorStats,
-  getSensors,
-} from "../../RobotSimulator/robotSimulatorSlice";
+import { getSensors } from "../../RobotSimulator/robotSimulatorSlice";
 import { Container } from "../components/Common/Container";
 import { StatusTile, StatusTileVariant } from "../components/Common/StatusTile";
 import { EditorControls, VMControls } from "./BlocklyView";
 import "./RobotView.css";
 
+function calculateCurrentTime() {
+  return +new Date(); // convert time to unix timestamp milliseconds
+}
+
 export const RobotView = () => {
-  const motorStats = useSelector(getMotorStats);
+  enum TimerState {
+    RUNNING = "running",
+    STOPPED = "stopped",
+    PAUSED = "paused",
+    NON_STARTED = "Not Started",
+  }
+
+  const executionState = useSelector(getExecutionState);
   const sensors = useSelector(getSensors);
 
-  const vm = useVM();
-  let robotHandle = vm.robot;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_currentTime, setCurrentTime] = useState(calculateCurrentTime());
+  const [currentState, setCurrentState] = useState(TimerState.NON_STARTED);
 
-  let getColorHex = () => {
+  const vm = useVM();
+  const robotHandle = vm.robot;
+
+  const getColorHex = () => {
     const colorSensorValue = robotHandle.getComplexSensorValue(
       1,
       "ColorSensor"
@@ -28,17 +43,82 @@ export const RobotView = () => {
       : "#ffffff";
   };
 
+  let updateCurrentTime = () => {
+    setCurrentTime(+new Date());
+  };
+
+  let startStopwatch = () => {
+    if (currentState === TimerState.RUNNING) {
+      // Timer already running
+      return;
+    }
+
+    setCurrentState(TimerState.RUNNING);
+    // start the timer again
+    const handle = window.setInterval(updateCurrentTime, 23);
+    return handle;
+  };
+
+  let stopStopwatch = () => {
+    if (currentState === TimerState.RUNNING) {
+      setCurrentState(TimerState.STOPPED);
+    }
+  };
+
+  let pauseStopwatch = () => {
+    if (currentState === TimerState.RUNNING) {
+      setCurrentState(TimerState.PAUSED);
+    }
+  };
+
+  // Using effect to update "currentState" to force RobotView to refresh
+  // similar to timer.tsx component because we are reading the sensor values
+  // but not store them in redux nor this component state.
+  // The plan forward is to either store the sensor values in redux to make them
+  // avilable to any view and also refresh any component that uses them or
+  // store the values in this component state.
+  useEffect(() => {
+    let handleToStop: number | undefined;
+    if (executionState === ExecutionState.RUNNING) {
+      handleToStop = startStopwatch();
+    } else if (
+      executionState === ExecutionState.STOPPED ||
+      executionState === ExecutionState.NONE
+    ) {
+      stopStopwatch();
+    } else if (executionState === ExecutionState.PAUSED) {
+      pauseStopwatch();
+    }
+    return () => {
+      if (handleToStop) {
+        clearInterval(handleToStop);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [executionState]);
+
+  if (sensors.motors.length > 0) {
+    const x = robotHandle.getMotorInputSignal(0);
+    console.log("motor power " + x);
+  }
+
   return (
     <>
       <Container className="simulator-view--panel__main robot-view">
         <div className="robot-view--stats">
-          <StatusTile label="Robot Motors" value={motorStats.length} />
-          {motorStats.map(([label, value], index) => (
+          <StatusTile label="Robot Motors" value={sensors.motors.length} />
+          {sensors.motors.map((motor, index) => (
             <StatusTile
-              key={index}
+              key={`motor-${index}`}
               variant={StatusTileVariant.active}
-              label={`Port ${label}`}
-              value={value}
+              label={motor.mountFaceName}
+              sublabel={`Channel: ${motor.channel}`}
+              value={robotHandle.getMotorInputSignal(motor.channel).toFixed(2)}
+              // value={(
+              //   robotHandle.getAnalogInput(sensor.channel) *
+              //   DISTANCE_SENSOR_RANGE *
+              //   100
+              // ).toFixed(1)}
             />
           ))}
         </div>


### PR DESCRIPTION
Before this change the information about the motors in RobotView was captured when setting the motors and not from the robot itself.

This now uses the RobotSpec and SimRobot, like the rest of the sensors, to decide what to present and get the actual values of the motors.


https://user-images.githubusercontent.com/187938/205295099-7e4cf85d-6f59-4668-8a54-9b53ebbd34e9.mp4

Depends on https://github.com/FRUK-Simulator/SimulatorCore/pull/194