### PR TITLE
ci: fix artifact generation path in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         - run: npm run build
           env:
             CI: true
-        - run: zip -r artifact.zip build
+        - run: zip -r artifact.zip dist
 
         - name: Declare some variables
           id: vars


### PR DESCRIPTION
Previously, with CRA (Create React App), the build ouputs were put in `build`. Now, with Vite, we changed this to `dist`. Fixing this little error.