### PR TITLE
chore: disable PR comment on release success

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    ["@semantic-release/github", { "successComment": false }]
   ]
 }


### PR DESCRIPTION
It feels more like spams generating new comment for every single PRs involved in a release. Disabling this behavior based on the docs here: https://github.com/semantic-release/github?tab=readme-ov-file#options