### PR TITLE
feat: home screen

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -4,7 +4,7 @@ import "./index.css";
 
 import { Route, Routes } from "react-router-dom";
 import { Layout } from "./components/Layout";
-import { Home } from "./views/Home";
+import { Home } from "./views/Home/Home";
 import { NotFound } from "./views/NotFound";
 import { Sandbox } from "./views/Sandbox";
 import { Lessons } from "./views/Lessons/Lessons";

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,9 +11,7 @@ const StyledLayout = styled.div`
 const Main = styled.main`
   display: flex;
   flex-direction: column;
-  padding: 1rem;
   flex: 1 0 auto;
-  background-color: var(--color-blue-light);
 `;
 
 export const Layout: FC<{ children: ReactNode }> = ({ children }) => {

--- a/src/index.css
+++ b/src/index.css
@@ -7,4 +7,5 @@ html {
   font-weight: var(--font-weight-default);
   line-height: var(--lineheight-text);
   color: var(--color-text-default);
+  background-color: var(--color-blue-light);
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,76 @@
+import { forwardRef, ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+type ButtonType = "primary" | "blue" | "secondary" | "tertiary";
+
+const StyledButton = styled.button<{
+  $type: ButtonType;
+}>`
+  outline: 0;
+  appearance: none;
+  justify-content: center;
+  align-items: center;
+  display: inline-flex;
+  padding: var(--spacing) var(--spacing-large);
+  color: var(--color-text-alt);
+  border-width: 0;
+  border-radius: var(--border-radius-small);
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-default);
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: var(--duration-promptly) all ease;
+  position: relative;
+  text-decoration: none;
+  box-shadow: 5px 5px 0 0 #000;
+  font-family: var(--font-family-heading);
+  white-space: nowrap;
+
+  ${(props) =>
+    props.$type === "primary" &&
+    `
+    background-color: var(--color-red);
+    color: var(--color-white);
+    &:hover {
+      background-color: var(--color-red-light);
+    }
+  `}
+
+  ${(props) =>
+    props.$type === "blue" &&
+    `
+    background-color: var(--color-blue-dark);
+    color: var(--color-white);
+    &:hover {
+      background-color: var(--color-blue-mid);
+    }
+  `}
+`;
+
+type Props = {
+  children: ReactNode;
+  /**
+   *  Convert this button to a link button
+   *  takes priority over onClick prop
+   */
+  to?: string;
+  onClick?: () => void;
+  type?: ButtonType;
+};
+
+export const Button = forwardRef<HTMLButtonElement, Props>(
+  ({ children, to, onClick, type = "primary" }, ref) => {
+    const navigate = useNavigate();
+    return (
+      <StyledButton
+        $type={type}
+        ref={ref}
+        onClick={to ? () => navigate(to) : onClick}
+      >
+        {children}
+      </StyledButton>
+    );
+  },
+);

--- a/src/ui/Typography.tsx
+++ b/src/ui/Typography.tsx
@@ -21,3 +21,12 @@ export const H3 = styled.h3`
 export const H4 = styled.h4`
   font-size: var(--font-size-x-large);
 `;
+
+export const Subheading1 = styled.h5`
+  font-size: var(--font-size-medium);
+`;
+
+export const Subheading2 = styled.h6`
+  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-bold);
+`;

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,5 +1,0 @@
-import { UnderConstruction } from "../components/UnderConstruction/UnderConstruction";
-
-export const Home = () => {
-  return <UnderConstruction title="Home page under construction" />;
-};

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -1,0 +1,90 @@
+import styled from "styled-components";
+import { H1, Subheading2 } from "../../ui/Typography";
+import { Button } from "../../ui/Button";
+import shapesBlueUrl from "./shapes-blue.svg";
+import shapesPinkUrl from "./shapes-pink.svg";
+
+const Wrap = styled.div`
+  padding: 48px 40px;
+  display: flex;
+  align-items: stretch;
+  flex-grow: 1;
+  flex-wrap: wrap;
+`;
+
+const Block = styled.div<{ color: string; bgUrl: string }>`
+  background-color: ${(props) => props.color};
+  background-image: url(${(props) => props.bgUrl});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  padding: 60px 90px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  color: var(--color-white);
+  flex: 1 1 50%;
+  min-width: 360px;
+  box-sizing: border-box;
+  align-items: flex-start;
+`;
+
+const BlockH1 = styled(H1)`
+  margin-top: 0;
+  margin-bottom: 0;
+`;
+
+// not in Design System spec but used in Figma page design
+// just do an adhoc implementation
+const Paragraph = styled.p`
+  font-size: 20px;
+  line-height: 24px;
+  margin-top: 16px;
+  margin-bottom: 32px;
+  flex-basis: 100px;
+`;
+
+const Subheading = styled(Subheading2)`
+  opacity: 0.75;
+`;
+
+const Spacer = styled.div<{ size?: number }>`
+  flex-grow: ${(props) => props.size ?? 1};
+`;
+
+export const Home = () => {
+  return (
+    <Wrap>
+      <Block color="var(--color-red)" bgUrl={shapesPinkUrl}>
+        <Subheading>&lt;Students&gt;</Subheading>
+        <Spacer size={2} />
+        <BlockH1>Play</BlockH1>
+        <Paragraph>
+          Learn how to code and put your skills to the test with our simulator.
+          Piece together blocks of code to make our robots move and solve
+          challenges. Solve every challenge to reconstruct our dismantled
+          robots!
+        </Paragraph>
+        <Spacer size={1} />
+        <Button type="blue" to="lessons">
+          START LEARNING!
+        </Button>
+      </Block>
+      <Block color="var(--color-blue)" bgUrl={shapesBlueUrl}>
+        <Subheading>&lt;Teachers&gt;</Subheading>
+        <Spacer size={2} />
+        <BlockH1>Teach</BlockH1>
+        <Paragraph>
+          The simulator has been produced by a group of software engineers at
+          Bloomberg in association with First UK. We equip young people with the
+          technical knowledge knowhow and soft skills to succeed in engineering.
+        </Paragraph>
+        <Spacer size={1} />
+        <Button type="blue" to="resources">
+          START TEACHING!
+        </Button>
+      </Block>
+    </Wrap>
+  );
+};

--- a/src/views/Home/shapes-blue.svg
+++ b/src/views/Home/shapes-blue.svg
@@ -1,0 +1,17 @@
+<svg width="680" height="674" viewBox="0 0 680 674" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g style="mix-blend-mode:lighten">
+<mask id="mask0_662_13956" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="680" height="674">
+<rect width="680" height="674" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_662_13956)">
+<rect x="247.761" y="203.27" width="201" height="201" rx="5" transform="rotate(-120 247.761 203.27)" fill="#C3D9FE" fill-opacity="0.1"/>
+<rect x="243.809" y="285.95" width="88.6898" height="231.63" rx="5" transform="rotate(105 243.809 285.95)" fill="#C3D9FE" fill-opacity="0.1"/>
+<circle opacity="0.9" cx="591.073" cy="3.90382" r="150" transform="rotate(150 591.073 3.90382)" fill="#C3D9FE" fill-opacity="0.1"/>
+<circle opacity="0.9" cx="236.48" cy="190.73" r="69.5" transform="rotate(-120 236.48 190.73)" fill="#C3D9FE" fill-opacity="0.1"/>
+<path d="M366.498 174.343C366.498 170.494 370.665 168.088 373.998 170.013L559.046 276.85C562.38 278.775 562.38 283.586 559.046 285.511L373.998 392.348C370.665 394.273 366.498 391.867 366.498 388.018L366.498 174.343Z" fill="#C3D9FE" fill-opacity="0.1"/>
+<path d="M11.3591 152.031C7.64128 151.035 6.39603 146.387 9.11769 143.666L91.4843 61.299C94.206 58.5774 98.8533 59.8226 99.8495 63.5404L129.998 176.055C130.994 179.773 127.592 183.175 123.874 182.179L11.3591 152.031Z" fill="#C3D9FE" fill-opacity="0.1"/>
+<path d="M586.401 396L565 392.193L616.599 184L638 187.807L586.401 396Z" fill="#C3D9FE" fill-opacity="0.1"/>
+<path d="M585.788 399.446L589.01 400.019L589.798 396.842L641.397 188.649L642.297 185.016L638.613 184.361L617.212 180.554L613.99 179.981L613.202 183.158L561.603 391.351L560.703 394.984L564.387 395.639L585.788 399.446Z" stroke="#C3D9FE" stroke-opacity="0.1" stroke-width="7"/>
+</g>
+</g>
+</svg>

--- a/src/views/Home/shapes-pink.svg
+++ b/src/views/Home/shapes-pink.svg
@@ -1,0 +1,14 @@
+<svg width="680" height="674" viewBox="0 0 680 674" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_662_13943" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="680" height="674">
+<rect width="680" height="674" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_662_13943)">
+<rect x="464" y="163" width="201" height="201" rx="5" transform="rotate(90 464 163)" fill="#FC73AC" fill-opacity="0.25"/>
+<rect x="526" y="86.7129" width="88.6898" height="231.63" rx="5" transform="rotate(-45 526 86.7129)" fill="#FC73AC" fill-opacity="0.25"/>
+<circle opacity="0.9" cx="70" cy="182" r="150" fill="#FC73AC" fill-opacity="0.25"/>
+<circle opacity="0.9" cx="467.5" cy="179.5" r="69.5" transform="rotate(90 467.5 179.5)" fill="#FC73AC" fill-opacity="0.25"/>
+<path d="M331.33 126.5C329.406 129.833 324.594 129.833 322.67 126.5L241.263 -14.5C239.339 -17.8334 241.745 -22 245.594 -22L408.406 -22C412.255 -22 414.661 -17.8333 412.737 -14.5L331.33 126.5Z" fill="#FC73AC" fill-opacity="0.25"/>
+<path d="M540 309.829L598.21 257L612.115 272.872L573.465 308.882L614 344.18L598.917 361L540 309.829Z" fill="#FC73AC" fill-opacity="0.25"/>
+<path d="M538.656 308.348L536.988 309.862L538.689 311.339L597.606 362.51L599.092 363.801L600.406 362.335L615.489 345.515L616.844 344.004L615.313 342.672L576.453 308.831L613.478 274.336L614.897 273.014L613.619 271.555L599.715 255.682L598.373 254.151L596.866 255.519L538.656 308.348Z" stroke="#FC73AC" stroke-opacity="0.25" stroke-width="4"/>
+</g>
+</svg>

--- a/src/views/Sandbox.tsx
+++ b/src/views/Sandbox.tsx
@@ -1,12 +1,14 @@
-import { H1, H2, H3, H4 } from "../ui/Typography";
+import { H1, H2, H3, H4, Subheading1, Subheading2 } from "../ui/Typography";
 
 export const Sandbox = () => {
   return (
-    <div>
+    <div style={{ padding: 40 }}>
       <H1>Heading 1</H1>
       <H2>Heading 2</H2>
       <H3>Heading 3</H3>
       <H4>Heading 4</H4>
+      <Subheading1>Subheading 1</Subheading1>
+      <Subheading2>Subheading 2</Subheading2>
       <p>Paragraph</p>
     </div>
   );


### PR DESCRIPTION
This PR implements home screen.

Goals for this implementation
- Aiming to provide good screen size compatibility for mainstream 4K/5K screens, laptops and tablets
- Aiming to avoid layout crashes for mobile device screen sizes, but mobile screen responsiveness is not in the compatibility list
- The implementation follows the designer's intention to have 2 blocks covering the whole home screen, with appropriate flexible variations for the margin gap between title/subtitle and buttons.
- Color blocks transfer from aligned in row to aligned in column, aiming to provide adequate UX to vertical screen ratios.

**4K large desktop screen W 2560**
<img width="2086" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/87c6fdd8-5d06-4695-9902-1e4f2c237e61">

**Large laptop W 1440**
<img width="1217" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/298434da-f829-41f9-8a4f-b9ff522b1971">

**Small laptop/large tablet W 1024**
<img width="1102" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/7e319782-7688-4778-8a80-75e73be02481">

**iPad Air 1180x820**
<img width="1224" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/a55407ee-9cb8-4da5-a122-6482dd68498c">

A few more extreme sizes

**iPhone 14 Pro Max 430x932**
<img width="486" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/7cd3b658-9c2c-46fd-a7cc-784ba83664e3">

**iPad air vertical**
<img width="688" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/16964e19-5a77-4d18-8e33-f944ba3fecff">

**iPad mini vertical**
<img width="633" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/d0e0bb85-ca0d-4b36-bad8-a0eaab637172">

**4K screen vertical**
<img width="783" alt="image" src="https://github.com/FRUK-Simulator/Simulator/assets/385786/fe9e378a-8035-4d41-aad0-d23a7bffc18f">
