### PR TITLE
ci: fix deployments by build outDir changed to `build` and re-enabling artifact generation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
     "plugin:react-hooks/recommended",
     "plugin:@tanstack/eslint-plugin-query/recommended",
   ],
-  ignorePatterns: ["dist", ".eslintrc.cjs"],
+  ignorePatterns: ["dist", "build", ".eslintrc.cjs"],
   parser: "@typescript-eslint/parser",
   plugins: ["react-refresh"],
   rules: {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,21 @@ jobs:
         env:
           CI: true
 
+      - run: zip -r artifact.zip build
+
       - name: Create Release
         id: create_release
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Asset for deployment scripts
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifact.zip
+          asset_name: artifact.zip
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 dist/
+build/
 
 # testing
 /coverage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [Vitest](https://vitest.dev/guide/) for more information.
 
 ### `npm run build`
 
-Builds the app for production to the `dist` folder.<br />
+Builds the app for production to the `build` folder.<br />
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.<br />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
+    "outDir": "build",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -13,13 +17,18 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }],
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,8 @@ import svgr from "vite-plugin-svgr";
 
 /** @type {import('vite').UserConfig} */
 export default {
+  build: {
+    outDir: './build'
+  },
   plugins: [svgr()],
 };


### PR DESCRIPTION
- **ci: changing output directory for prod builds to `build`**
- **ci: re-enabling artifact.zip generation**

### What's going on?

The machine where the website is deployed is periodically checking for the existence of an `artifact.zip` file, containing a `build` folder inside, with the required assets for the deployment.

A manual Github workflow has been added to trigger the release.