### PR TITLE
Implement simulator screen

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -22,7 +22,10 @@ const AppRoutes = () => {
         <Route index element={<Home />} />
         <Route path="lessons" element={<Lessons />} />
         <Route path="lessons/:lessonId" element={<Challenges />} />
-        <Route path="lessons/:lessonId/:challengeId" element={<Challenge />} />
+        <Route
+          path="lessons/:lessonId/challenges/:challengeId"
+          element={<Challenge />}
+        />
         <Route path="resources" element={<Resources />} />
         <Route path="sandbox" element={<Sandbox />} />
         {/* debugging playground */}

--- a/src/components/ChallengeCard/ChallengeCard.tsx
+++ b/src/components/ChallengeCard/ChallengeCard.tsx
@@ -102,7 +102,7 @@ export const ChallengeCard: FC<Props> = ({
         <Title>{title}</Title>
         <Paragraph>{description}</Paragraph>
         <Spacer size={1} />
-        <Button type="primary" to={challengeId}>
+        <Button type="primary" to={`challenges/${challengeId}`}>
           LET'S GO!
         </Button>
       </ContentWrap>

--- a/src/core/data-loader.ts
+++ b/src/core/data-loader.ts
@@ -4,6 +4,7 @@ import challengeIconCUrl from "../assets/challenge-icon-c.svg";
 
 type Lesson = {
   lessonId: string;
+  title: string;
 };
 
 export type Challenge = {
@@ -13,6 +14,21 @@ export type Challenge = {
   description: string;
   iconUrl: string;
 };
+
+const dummyLessons: Lesson[] = [
+  {
+    lessonId: "1",
+    title: "Lesson 1",
+  },
+  {
+    lessonId: "2",
+    title: "Lesson 2",
+  },
+  {
+    lessonId: "3",
+    title: "Lesson 3",
+  },
+];
 
 const dummyChallenges: Challenge[] = [
   {
@@ -49,15 +65,32 @@ const dummyChallenges: Challenge[] = [
  * this is why we made it async so the switch will be seamless.
  */
 export const loadLessonsData = async (): Promise<Lesson[]> => {
-  // TODO: fill the data
-  return [];
+  return dummyLessons;
 };
 
 /**
- * Load the data for the challenges.
+ * Load the data for specific lesson.
+ */
+export const loadLessonData = async (
+  lessonId: string,
+): Promise<Lesson | undefined> => {
+  return dummyLessons.find((l) => l.lessonId === lessonId);
+};
+
+/**
+ * Load the data for challenges.
  */
 export const loadChallengesData = async (
   lessonId: string,
 ): Promise<Challenge[]> => {
   return dummyChallenges.filter((c) => c.lessonId === lessonId);
+};
+
+/**
+ * Load the data for specific challenge.
+ */
+export const loadChallengeData = async (
+  challengeId: string,
+): Promise<Challenge> => {
+  return dummyChallenges.find((c) => c.challengeId === challengeId)!;
 };

--- a/src/hooks/query-hooks.ts
+++ b/src/hooks/query-hooks.ts
@@ -1,11 +1,37 @@
 import { QueryClient, useQuery } from "@tanstack/react-query";
-import { loadChallengesData } from "../core/data-loader";
+import {
+  loadChallengeData,
+  loadChallengesData,
+  loadLessonData,
+  loadLessonsData,
+} from "../core/data-loader";
 
 export const queryClient = new QueryClient();
+
+export const useLessonsQuery = () => {
+  return useQuery({
+    queryKey: ["lessons"],
+    queryFn: () => loadLessonsData(),
+  });
+};
+
+export const useLessonQuery = (lessonId: string) => {
+  return useQuery({
+    queryKey: ["lesson", lessonId],
+    queryFn: () => loadLessonData(lessonId),
+  });
+};
 
 export const useChallengesQuery = (lessonId: string) => {
   return useQuery({
     queryKey: ["challenges", lessonId],
     queryFn: () => loadChallengesData(lessonId),
+  });
+};
+
+export const useChallengeQuery = (challengeId: string) => {
+  return useQuery({
+    queryKey: ["challenge", challengeId],
+    queryFn: () => loadChallengeData(challengeId),
   });
 };

--- a/src/views/Challenge/Challenge.tsx
+++ b/src/views/Challenge/Challenge.tsx
@@ -1,3 +1,34 @@
-export const Challenge = () => {
-  return <div>Challenge</div>;
+import { FC } from "react";
+import { useChallengeQuery, useLessonQuery } from "../../hooks/query-hooks";
+import { useAppParams } from "../../hooks/util-hooks";
+import { ChallengeHeader } from "./ChallengeHeader";
+import { H4 } from "../../ui/Typography";
+
+/**
+ * Route view component hosting simulator
+ */
+export const Challenge: FC = () => {
+  const { lessonId, challengeId } = useAppParams();
+
+  if (!lessonId || !challengeId) {
+    throw new Error("Lesson ID or Challenge ID is not found in current URL");
+  }
+
+  const { data: challenge } = useChallengeQuery(challengeId);
+
+  const { data: lesson } = useLessonQuery(lessonId);
+
+  return (
+    <>
+      <ChallengeHeader
+        title={challenge?.title ?? ""}
+        subtitle={lesson?.title ?? ""}
+      />
+      {/* TODO: debug purpose, cleanup after view implementation is done */}
+      <H4>Fetched lesson object</H4>
+      <pre>{JSON.stringify(lesson, undefined, 2)}</pre>
+      <H4>Fetched challenge object</H4>
+      <pre>{JSON.stringify(challenge, undefined, 2)}</pre>
+    </>
+  );
 };

--- a/src/views/Challenge/ChallengeHeader.tsx
+++ b/src/views/Challenge/ChallengeHeader.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import styled from "styled-components";
+import { H3, Subheading1 } from "../../ui/Typography";
+import { Timer } from "./Timer";
+
+type Props = {
+  title: string;
+  subtitle: string;
+};
+
+const Header = styled.div`
+  padding: 20px 70px;
+  background-color: var(--color-blue-dark);
+  color: var(--color-white);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const SubHeading = styled(Subheading1)`
+  color: var(--color-grey-mid);
+  margin: 0;
+`;
+
+const Heading = styled(H3)`
+  margin: 4px 0 0;
+`;
+
+export const ChallengeHeader: FC<Props> = ({ title, subtitle }) => {
+  return (
+    <>
+      <Header>
+        <div>
+          <SubHeading>&lt;{subtitle}&gt;</SubHeading>
+          <Heading>{title}</Heading>
+        </div>
+        <Timer />
+      </Header>
+    </>
+  );
+};

--- a/src/views/Challenge/Timer.tsx
+++ b/src/views/Challenge/Timer.tsx
@@ -1,0 +1,22 @@
+import { FC } from "react";
+import StopwatchIcon from "./stopwatch.svg?react";
+import styled from "styled-components";
+
+const Wrap = styled.div`
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const Timer: FC = () => {
+  return (
+    <Wrap>
+      <StopwatchIcon height={32} />
+      {/* TODO: figure out with stackholder how the timer suppose to work */}
+      <span>0000.00</span>
+    </Wrap>
+  );
+};

--- a/src/views/Challenge/stopwatch.svg
+++ b/src/views/Challenge/stopwatch.svg
@@ -1,0 +1,7 @@
+<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 12.75V18.4167L21.25 22.6667" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.9997 30.4583C10.3492 30.4583 4.95801 25.0671 4.95801 18.4167C4.95801 11.7662 10.3492 6.375 16.9997 6.375C23.6501 6.375 29.0413 11.7662 29.0413 18.4167C29.0413 25.0671 23.6501 30.4583 16.9997 30.4583Z" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26.1943 8.72239L28.3336 6.02051" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 2.83333H21.25" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.0003 2.83301V6.37467" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
This is ready for review. I decided to split simulator implementation into small PRs, this one setup skeleton structure for the layout, as well as finish up initial design of the dummy data loader, hopefully can be used across all data loading related pages: lessons/resources/challenges etc.